### PR TITLE
doc(#90): cross link other addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ test('my test', async function (assert) {
 List of addons that use and wrap `ember-resources` to provide more specific functionality:
 
 - [ember-data-resources](https://github.com/NullVoxPopuli/ember-data-resources) - resources for reactive data fetching with ember-data
+- [ember-array-map-resource](https://github.com/NullVoxPopuli/ember-array-map-resource) - provides a useArrayMap function which returns a resource that reactively maps data per-element, so that when the overall collection is dirtied, only the changed/new/removed elements affect the mapped collection
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -591,6 +591,11 @@ test('my test', async function (assert) {
   assert.equal(foo.data.num, 6);
 ```
 
+## Related addons
+
+List of addons that use and wrap `ember-resources` to provide more specific functionality:
+
+- [ember-data-resources](https://github.com/NullVoxPopuli/ember-data-resources) - resources for reactive data fetching with ember-data
 
 ## Contributing
 


### PR DESCRIPTION
- To give an example of how to use this ember-resources
- To make sure people are not reinventing the wheel
- To encourage people to create their own addons