### PR TITLE
fix(useTask): re-test against ember-concurrency@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         ember-try-scenario:
           - ember-3.25
           - ember-3.26
+          - ember-concurrency-v1
           - ember-release
           - ember-beta
           - ember-canary

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+/package-lock.json.ember-try

--- a/addon/-private/resources/ember-concurrency-task.ts
+++ b/addon/-private/resources/ember-concurrency-task.ts
@@ -1,3 +1,6 @@
+/* eslint-disable ember/no-get */
+import { get as consumeTag } from '@ember/object';
+
 import { LifecycleResource } from './lifecycle';
 
 export interface TaskIsh<Return = unknown, Args extends unknown[] = unknown[]> {
@@ -44,6 +47,11 @@ export class TaskResource<
   }
 
   get value() {
+    // in ember-concurrency@v1, value is not consumable tracked data
+    // until the task is resolved, so we need to consume the isRunning
+    // property so that value updates
+    consumeTag(this.currentTask, 'isRunning');
+
     return this.currentTask.value ?? this.lastTask?.value;
   }
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -46,6 +46,15 @@ module.exports = async function () {
           },
         },
       },
+      {
+        name: 'ember-concurrency-v1',
+        npm: {
+          devDependencies: {
+            'ember-concurrency': '^1.0.0',
+            'ember-concurrency-decorators': '^2.0.0',
+          },
+        },
+      },
       embroiderSafe(),
       embroiderOptimized(),
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
+        "@embroider/macros": "^0.47.1",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^6.0.0",
         "ember-cli-typescript": "^4.2.1"
@@ -2176,6 +2177,26 @@
         "node": "10.* || 12.* || >= 14"
       }
     },
+    "node_modules/@embroider/core/node_modules/@embroider/macros": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.33.0.tgz",
+      "integrity": "sha512-nl/1zRn+Wd3MO8Bb+YPqHmFl/2vwQLTsEB6Zt+K9bWXsM/kA+dPCeeCReLN6PbkMP16xxqtNSIrQ8Y49hnWjpg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "@embroider/core": "0.33.0",
+        "assert-never": "^1.1.0",
+        "ember-cli-babel": "^7.23.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.8.1",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "10.* || 12.* || >= 14"
+      }
+    },
     "node_modules/@embroider/core/node_modules/async-disk-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
@@ -2414,23 +2435,81 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.33.0.tgz",
-      "integrity": "sha512-nl/1zRn+Wd3MO8Bb+YPqHmFl/2vwQLTsEB6Zt+K9bWXsM/kA+dPCeeCReLN6PbkMP16xxqtNSIrQ8Y49hnWjpg==",
-      "dev": true,
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.47.1.tgz",
+      "integrity": "sha512-asTmkWMmagL/ID38R8eqwIg3fRPBF9AYE+FBr83u4KW+JUxKloILEosO8tBlu1bEzXqGBb3aO6fAq/mDMBMn0Q==",
       "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
-        "@embroider/core": "0.33.0",
-        "assert-never": "^1.1.0",
-        "ember-cli-babel": "^7.23.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.8.1",
+        "@embroider/shared-internals": "0.47.1",
+        "assert-never": "^1.2.1",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
         "semver": "^7.3.2"
       },
       "engines": {
-        "node": "10.* || 12.* || >= 14"
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.47.1.tgz",
+      "integrity": "sha512-Sb4AGcOkfU3ttIvGHqa574G6LNQbmo9tAQf+Wk9xPhE0RlNk7JrYrHx8FTpz3QUoLI43zoQ9g1oTiKvclnALKQ==",
+      "dependencies": {
+        "babel-import-util": "^0.2.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@embroider/shared-internals": {
@@ -8368,8 +8447,7 @@
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
     },
     "node_modules/assert/node_modules/inherits": {
       "version": "2.0.1",
@@ -19511,7 +19589,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -19527,7 +19604,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -22175,7 +22251,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -24436,7 +24511,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -24451,7 +24525,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -29203,8 +29276,7 @@
     "node_modules/typescript-memoize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.0.1.tgz",
-      "integrity": "sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==",
-      "dev": true
+      "integrity": "sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w=="
     },
     "node_modules/uc.micro": {
       "version": "1.0.6",
@@ -30559,7 +30631,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -32253,6 +32324,23 @@
         "wrap-legacy-hbs-plugin-if-needed": "^1.0.1"
       },
       "dependencies": {
+        "@embroider/macros": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.33.0.tgz",
+          "integrity": "sha512-nl/1zRn+Wd3MO8Bb+YPqHmFl/2vwQLTsEB6Zt+K9bWXsM/kA+dPCeeCReLN6PbkMP16xxqtNSIrQ8Y49hnWjpg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/traverse": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "@embroider/core": "0.33.0",
+            "assert-never": "^1.1.0",
+            "ember-cli-babel": "^7.23.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.8.1",
+            "semver": "^7.3.2"
+          }
+        },
         "async-disk-cache": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
@@ -32446,20 +32534,66 @@
       }
     },
     "@embroider/macros": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.33.0.tgz",
-      "integrity": "sha512-nl/1zRn+Wd3MO8Bb+YPqHmFl/2vwQLTsEB6Zt+K9bWXsM/kA+dPCeeCReLN6PbkMP16xxqtNSIrQ8Y49hnWjpg==",
-      "dev": true,
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.47.1.tgz",
+      "integrity": "sha512-asTmkWMmagL/ID38R8eqwIg3fRPBF9AYE+FBr83u4KW+JUxKloILEosO8tBlu1bEzXqGBb3aO6fAq/mDMBMn0Q==",
       "requires": {
-        "@babel/core": "^7.12.3",
-        "@babel/traverse": "^7.12.1",
-        "@babel/types": "^7.12.1",
-        "@embroider/core": "0.33.0",
-        "assert-never": "^1.1.0",
-        "ember-cli-babel": "^7.23.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.8.1",
+        "@embroider/shared-internals": "0.47.1",
+        "assert-never": "^1.2.1",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "0.47.1",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.47.1.tgz",
+          "integrity": "sha512-Sb4AGcOkfU3ttIvGHqa574G6LNQbmo9tAQf+Wk9xPhE0RlNk7JrYrHx8FTpz3QUoLI43zoQ9g1oTiKvclnALKQ==",
+          "requires": {
+            "babel-import-util": "^0.2.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "resolve-package-path": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+          "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+          "requires": {
+            "path-root": "^0.1.1"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "@embroider/shared-internals": {
@@ -37108,8 +37242,7 @@
     "assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -46284,7 +46417,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -46293,8 +46425,7 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         }
       }
     },
@@ -48399,7 +48530,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -50266,7 +50396,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -50275,7 +50404,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -54046,8 +54174,7 @@
     "typescript-memoize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typescript-memoize/-/typescript-memoize-1.0.1.tgz",
-      "integrity": "sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==",
-      "dev": true
+      "integrity": "sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -55154,8 +55281,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@ember/test-waiters": "^3.0.0",
+    "@embroider/macros": "^0.47.1",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^6.0.0",
     "ember-cli-typescript": "^4.2.1"
@@ -44,9 +45,6 @@
     "@nullvoxpopuli/eslint-configs": "^1.4.0",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
-    "@types/ember-data": "^3.16.15",
-    "@types/ember-qunit": "^3.4.14",
-    "@types/ember-resolver": "^5.0.10",
     "@types/ember__application": "^3.16.3",
     "@types/ember__array": "^3.16.4",
     "@types/ember__component": "^3.16.6",
@@ -64,6 +62,9 @@
     "@types/ember__test": "^3.16.1",
     "@types/ember__test-helpers": "^2.0.1",
     "@types/ember__utils": "^3.16.2",
+    "@types/ember-data": "^3.16.15",
+    "@types/ember-qunit": "^3.4.14",
+    "@types/ember-resolver": "^5.0.10",
     "@types/htmlbars-inline-precompile": "^1.0.1",
     "@types/qunit": "^2.11.2",
     "@types/rsvp": "^4.0.4",

--- a/tests/unit/use-task-test.ts
+++ b/tests/unit/use-task-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { setComponentTemplate } from '@ember/component';
@@ -6,132 +7,141 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest, setupTest } from 'ember-qunit';
 
-import { restartableTask, timeout } from 'ember-concurrency';
+import { dependencySatisfies, importSync } from '@embroider/macros';
 import { taskFor } from 'ember-concurrency-ts';
 import { useTask } from 'ember-resources';
 
 module('useTask', function () {
-  module('in JS', function (hooks) {
-    setupTest(hooks);
-
-    test('it works', async function (assert) {
-      class Test {
-        @tracked input = '';
-
-        search = useTask(this, taskFor(this._search), () => [this.input]);
-
-        @restartableTask
-        *_search(input: string) {
-          // or some bigger timeout for an actual search task to debounce
-          yield timeout(0);
-
-          // or some api data if actual search task
-          return { results: [input] };
-        }
+  if (dependencySatisfies('ember-concurrency', '^2.0.0')) {
+    module('ember-concurrency@v2', function () {
+      interface EConcurrencyV2 {
+        timeout: (wait: number) => Promise<void>;
+        restartableTask: PropertyDecorator;
       }
 
-      let foo = new Test();
+      const { restartableTask, timeout } = importSync('ember-concurrency') as EConcurrencyV2;
 
-      // task is initiated upon first access
-      foo.search;
-      await settled();
+      module('in JS', function (hooks) {
+        setupTest(hooks);
 
-      assert.equal(foo.search.value, null);
-      assert.false(foo.search.isFinished);
-      assert.true(foo.search.isRunning);
+        test('it works', async function (assert) {
+          class Test {
+            @tracked input = '';
 
-      await settled();
+            search = useTask(this, taskFor(this._search), () => [this.input]);
 
-      assert.true(foo.search.isFinished);
-      assert.false(foo.search.isRunning);
-      assert.deepEqual(foo.search.value, { results: [''] });
+            @restartableTask
+            *_search(input: string) {
+              // or some bigger timeout for an actual search task to debounce
+              yield timeout(0);
 
-      foo.input = 'Hello there!';
-      await settled();
+              // or some api data if actual search task
+              return { results: [input] };
+            }
+          }
 
-      assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
-      assert.false(foo.search.isFinished);
-      assert.true(foo.search.isRunning);
+          let foo = new Test();
 
-      await settled();
+          // task is initiated upon first access
+          foo.search;
+          await settled();
 
-      assert.true(foo.search.isFinished);
-      assert.false(foo.search.isRunning);
-      assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
-    });
+          assert.equal(foo.search.value, null);
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
 
-    test('it works without the thunk', async function (assert) {
-      class Test {
-        @tracked input = '';
+          await settled();
 
-        search = useTask(this, taskFor(this._search));
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: [''] });
 
-        @restartableTask
-        *_search() {
-          // NOTE: args must be consumed before the first yield
-          let { input } = this;
+          foo.input = 'Hello there!';
+          await settled();
 
-          // or some bigger timeout for an actual search task to debounce
-          yield timeout(0);
+          assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
 
-          // or some api data if actual search task
-          return { results: [input] };
-        }
-      }
+          await settled();
 
-      let foo = new Test();
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
+        });
 
-      // task is initiated upon first access
-      foo.search;
-      await settled();
+        test('it works without the thunk', async function (assert) {
+          class Test {
+            @tracked input = '';
 
-      assert.equal(foo.search.value, null);
-      assert.false(foo.search.isFinished);
-      assert.true(foo.search.isRunning);
+            search = useTask(this, taskFor(this._search));
 
-      await settled();
+            @restartableTask
+            *_search() {
+              // NOTE: args must be consumed before the first yield
+              let { input } = this;
 
-      assert.true(foo.search.isFinished);
-      assert.false(foo.search.isRunning);
-      assert.deepEqual(foo.search.value, { results: [''] });
+              // or some bigger timeout for an actual search task to debounce
+              yield timeout(0);
 
-      foo.input = 'Hello there!';
-      await settled();
+              // or some api data if actual search task
+              return { results: [input] };
+            }
+          }
 
-      assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
-      assert.false(foo.search.isFinished);
-      assert.true(foo.search.isRunning);
+          let foo = new Test();
 
-      await settled();
+          // task is initiated upon first access
+          foo.search;
+          await settled();
 
-      assert.true(foo.search.isFinished);
-      assert.false(foo.search.isRunning);
-      assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
-    });
-  });
+          assert.equal(foo.search.value, null);
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
 
-  module('in templates', function (hooks) {
-    setupRenderingTest(hooks);
+          await settled();
 
-    test('it works', async function (assert) {
-      class Test extends Component {
-        @tracked input = 'Hello there';
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: [''] });
 
-        search = useTask(this, taskFor(this._search), () => [this.input]);
+          foo.input = 'Hello there!';
+          await settled();
 
-        @restartableTask
-        *_search(input: string) {
-          yield timeout(50);
+          assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
 
-          return input;
-        }
-      }
+          await settled();
 
-      const TestComponent = setComponentTemplate(hbs`{{yield this}}`, Test);
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
+        });
+      });
 
-      this.setProperties({ TestComponent });
+      module('in templates', function (hooks) {
+        setupRenderingTest(hooks);
 
-      render(hbs`
+        test('it works', async function (assert) {
+          class Test extends Component {
+            @tracked input = 'Hello there';
+
+            search = useTask(this, taskFor(this._search), () => [this.input]);
+
+            @restartableTask
+            *_search(input: string) {
+              yield timeout(50);
+
+              return input;
+            }
+          }
+
+          const TestComponent = setComponentTemplate(hbs`{{yield this}}`, Test);
+
+          this.setProperties({ TestComponent });
+
+          render(hbs`
         <this.TestComponent as |ctx|>
           {{#if ctx.search.isRunning}}
             Loading
@@ -141,14 +151,203 @@ module('useTask', function () {
         </this.TestComponent>
       `);
 
-      // This could introduce flakiness / timing issues
-      await timeout(10);
+          // This could introduce flakiness / timing issues
+          await timeout(10);
 
-      assert.dom().hasText('Loading');
+          assert.dom().hasText('Loading');
 
-      await settled();
+          await settled();
 
-      assert.dom().hasText('Hello there');
+          assert.dom().hasText('Hello there');
+        });
+      });
     });
-  });
+  } else {
+    module('ember-concurrency@v1', function () {
+      interface EConcurrencyV2 {
+        timeout: (wait: number) => Promise<void>;
+        restartableTask: PropertyDecorator;
+      }
+
+      interface EConcurrencyDecorators {
+        restartableTask: PropertyDecorator;
+      }
+
+      const { timeout } = importSync('ember-concurrency') as EConcurrencyV2;
+      const { restartableTask } = importSync(
+        'ember-concurrency-decorators'
+      ) as EConcurrencyDecorators;
+
+      module('in JS', function (hooks) {
+        setupTest(hooks);
+
+        test('it works', async function (assert) {
+          class Test {
+            @tracked input = '';
+
+            search = useTask(this, taskFor(this._search), () => [this.input]);
+
+            @restartableTask
+            *_search(input: string) {
+              // or some bigger timeout for an actual search task to debounce
+              yield timeout(0);
+
+              // or some api data if actual search task
+              return { results: [input] };
+            }
+          }
+
+          let foo = new Test();
+
+          // task is initiated upon first access
+          foo.search;
+          await settled();
+
+          assert.equal(foo.search.value, null);
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
+
+          await settled();
+
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: [''] });
+
+          foo.input = 'Hello there!';
+          await settled();
+
+          assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
+
+          await settled();
+
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
+        });
+
+        test('it works without the thunk', async function (assert) {
+          class Test {
+            @tracked input = '';
+
+            search = useTask(this, taskFor(this._search));
+
+            @restartableTask
+            *_search() {
+              // NOTE: args must be consumed before the first yield
+              let { input } = this;
+
+              // or some bigger timeout for an actual search task to debounce
+              yield timeout(0);
+
+              // or some api data if actual search task
+              return { results: [input] };
+            }
+          }
+
+          let foo = new Test();
+
+          // task is initiated upon first access
+          foo.search;
+          await settled();
+
+          assert.equal(foo.search.value, null);
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
+
+          await settled();
+
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: [''] });
+
+          foo.input = 'Hello there!';
+          await settled();
+
+          assert.deepEqual(foo.search.value, { results: [''] }, 'previous value is retained');
+          assert.false(foo.search.isFinished);
+          assert.true(foo.search.isRunning);
+
+          await settled();
+
+          assert.true(foo.search.isFinished);
+          assert.false(foo.search.isRunning);
+          assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
+        });
+      });
+
+      module('in templates', function (hooks) {
+        setupRenderingTest(hooks);
+
+        test('it works', async function (assert) {
+          class Test extends Component {
+            @tracked input = 'Hello there';
+
+            search = useTask(this, taskFor(this._search), () => [this.input]);
+
+            @restartableTask
+            *_search(input: string) {
+              yield timeout(50);
+
+              return input;
+            }
+          }
+
+          const TestComponent = setComponentTemplate(hbs`{{yield this}}`, Test);
+
+          this.setProperties({ TestComponent });
+
+          render(hbs`
+            <this.TestComponent as |ctx|>
+              {{#if ctx.search.isRunning}}
+                Loading
+              {{else}}
+                {{ctx.search.value}}
+              {{/if}}
+            </this.TestComponent>
+          `);
+
+          // This could introduce flakiness / timing issues
+          await timeout(10);
+
+          assert.dom().hasText('Loading');
+
+          await settled();
+
+          assert.dom().hasText('Hello there');
+        });
+
+        test('works when accessed via getter', async function (assert) {
+          class Test extends Component {
+            get colors() {
+              return this.foundColors?.value ?? ['nothing to see here'];
+            }
+
+            foundColors = useTask(this, this.findColors as any);
+
+            @restartableTask
+            // eslint-disable-next-line require-yield
+            *findColors() {
+              return ['red', 'green', 'blue'];
+            }
+          }
+
+          const TestComponent = setComponentTemplate(hbs`{{yield this}}`, Test);
+
+          this.setProperties({ TestComponent });
+
+          render(hbs`
+            <this.TestComponent as |ctx|>
+              {{ctx.colors}}
+            </this.TestComponent>
+          `);
+
+          await settled();
+
+          assert.dom().hasText('red,green,blue');
+        });
+      });
+    });
+  }
 });


### PR DESCRIPTION
idk what happened to the ec@1 testing... but this brings it back and fixes an issue encountered only in ember-concurrency@v1 where _not_ accessing the isRunning property on the task means that `value` won't update when the task finally resolves.