### PR TITLE
refactor(function-runner): Refactored some Promise lines

### DIFF
--- a/ember-resources/src/-private/resources/function-runner.ts
+++ b/ember-resources/src/-private/resources/function-runner.ts
@@ -57,20 +57,11 @@ export class TrackedFunctionRunner<
     let value = fn(previousValue, ...[]);
 
     // disconnect from the tracking frame, no matter the type of function
-    await Promise.resolve();
+    // and resolve value if promise
+    value = await Promise.resolve(value);
 
     if (isDestroying(this) || isDestroyed(this)) {
       return;
-    }
-
-    if (typeof value === 'object' && 'then' in value) {
-      // value is actually a promise, so we don't want to return
-      // an unresolved promise.
-      value = await value;
-
-      if (isDestroying(this) || isDestroyed(this)) {
-        return;
-      }
     }
 
     this[SECRET_VALUE] = value;


### PR DESCRIPTION
It seems that we didn't have to call `Promise.resolve` twice, and we
also could just resolve the value in either case of being a plain value
or a promise.

Seems to work locally with tests, but I will be depending on ci testing