### PR TITLE
fix: Move `@ember/test-waiters` to peerDependencies

### DIFF
--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -38,7 +38,9 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.2.0",
-    "@embroider/macros": "^1.2.0",
+    "@embroider/macros": "^1.2.0"
+  },
+  "peerDependencies": {
     "@ember/test-waiters": "^3.0.0"
   },
   "devDependencies": {
@@ -48,6 +50,7 @@
     "@babel/plugin-syntax-decorators": "7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-typescript": "7.16.7",
+    "@ember/test-waiters": "^3.0.0",
     "@embroider/addon-dev": "1.2.0",
     "@nullvoxpopuli/eslint-configs": "^2.1.1",
     "@semantic-release/changelog": "^5.0.0",


### PR DESCRIPTION
Follow up to https://github.com/NullVoxPopuli/ember-resources/pull/407#issuecomment-1051102858

<img width="958" alt="image" src="https://user-images.githubusercontent.com/685034/155810333-b8fca331-b913-4b7c-82f2-9451d3e5c7ac.png">
