### PR TITLE
fix(docs, Resource): there is no second arg passed to the constructor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ _More information contained in the `docs` folder_.
 
 High-fidelity sourcemaps are provided in the original typescript.
 However, you must be using embroider to take advantage of them.
-Sourcemaps should work with ember-auto-import@v2+ in non-embroider builds as well, 
+Sourcemaps should work with ember-auto-import@v2+ in non-embroider builds as well,
 but is untested.
 
 

--- a/ember-resources/src/core/resource.ts
+++ b/ember-resources/src/core/resource.ts
@@ -29,8 +29,8 @@ import type { ArgsWrapper, Cache, Thunk } from './types';
  * class MyResource extends Resource {
  *   @tracked customState;
  *
- *   constructor(owner, args) {
- *     super(owner, args);
+ *   constructor(owner) {
+ *     super(owner);
  *
  *     registerDestructor(() => this.interpreter.stop());
  *   }


### PR DESCRIPTION
… of Resource