### PR TITLE
Revert "chore(deps): update dependency typescript to v4.6.4"

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,6 @@
     "typedoc-plugin-markdown": "^3.11.11",
     "typedoc-plugin-markdown-pages": "^0.3.0",
     "typedoc-plugin-mdn-links": "^1.0.4",
-    "typescript": "4.6.4"
+    "typescript": "4.6.3"
   }
 }

--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -128,7 +128,7 @@
     "rollup-plugin-ts": "^2.0.5",
     "semantic-release": "^19.0.2",
     "tslib": "^2.3.1",
-    "typescript": "~4.6.0"
+    "typescript": "~4.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,15 +72,15 @@ importers:
       typedoc-plugin-markdown: ^3.11.11
       typedoc-plugin-markdown-pages: ^0.3.0
       typedoc-plugin-mdn-links: ^1.0.4
-      typescript: 4.6.4
+      typescript: 4.6.3
     devDependencies:
-      typedoc: 0.22.12_typescript@4.6.4
+      typedoc: 0.22.12_typescript@4.6.3
       typedoc-github-wiki-theme: 1.0.0_12bbd5f5da74caa5f62982ac395382df
       typedoc-gitlab-wiki-theme: 1.0.0_12bbd5f5da74caa5f62982ac395382df
       typedoc-plugin-markdown: 3.11.14_typedoc@0.22.12
       typedoc-plugin-markdown-pages: 0.3.0
       typedoc-plugin-mdn-links: 1.0.5_typedoc@0.22.12
-      typescript: 4.6.4
+      typescript: 4.6.3
 
   ember-resources:
     specifiers:
@@ -123,7 +123,7 @@ importers:
       rollup-plugin-ts: ^2.0.5
       semantic-release: ^19.0.2
       tslib: ^2.3.1
-      typescript: ~4.6.0
+      typescript: ~4.2.0
     dependencies:
       '@babel/runtime': 7.17.8
       '@embroider/addon-shim': 1.5.0
@@ -139,7 +139,7 @@ importers:
       '@ember/test-waiters': 3.0.1
       '@embroider/addon-dev': 1.2.0_rollup@2.72.0
       '@glimmer/tracking': 1.0.4
-      '@nullvoxpopuli/eslint-configs': 2.2.0_typescript@4.6.3
+      '@nullvoxpopuli/eslint-configs': 2.2.0_typescript@4.2.4
       '@semantic-release/changelog': 6.0.1_semantic-release@19.0.2
       '@semantic-release/git': 10.0.1_semantic-release@19.0.2
       '@types/ember__component': 4.0.5
@@ -162,10 +162,10 @@ importers:
       npm-run-all: 4.1.5
       rollup: 2.72.0
       rollup-plugin-terser: 7.0.2_rollup@2.72.0
-      rollup-plugin-ts: 2.0.5_8a4919141d01bc826ac533e6fad3b657
+      rollup-plugin-ts: 2.0.5_a74e15baef0083ab3d8fd1c7f2ec00bb
       semantic-release: 19.0.2
       tslib: 2.3.1
-      typescript: 4.6.3
+      typescript: 4.2.4
 
   testing/build:
     specifiers:
@@ -4451,12 +4451,12 @@ packages:
       - typescript
     dev: true
 
-  /@nullvoxpopuli/eslint-configs/2.2.0_typescript@4.5.5:
+  /@nullvoxpopuli/eslint-configs/2.2.0_typescript@4.2.4:
     resolution: {integrity: sha512-qrDQcICfqZ0zOCKqYkENrUDfGgobC7pRZTO5htR8HjG2DJDcS5zhTVrztYWvnlYx2NtrR3TUksYXiteTZ7BKCQ==}
     engines: {node: '>= v12.0.0'}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.1_78ba2542c270c83b2a80bb1c125195b6
-      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.5.5
+      '@typescript-eslint/eslint-plugin': 5.12.1_011f416f0b1f048c6baea22941945307
+      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.2.4
       babel-eslint: 10.1.0_eslint@7.32.0
       eslint: 7.32.0
       eslint-config-prettier: 8.4.0_eslint@7.32.0
@@ -4474,12 +4474,12 @@ packages:
       - typescript
     dev: true
 
-  /@nullvoxpopuli/eslint-configs/2.2.0_typescript@4.6.3:
+  /@nullvoxpopuli/eslint-configs/2.2.0_typescript@4.5.5:
     resolution: {integrity: sha512-qrDQcICfqZ0zOCKqYkENrUDfGgobC7pRZTO5htR8HjG2DJDcS5zhTVrztYWvnlYx2NtrR3TUksYXiteTZ7BKCQ==}
     engines: {node: '>= v12.0.0'}
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.12.1_75ac8a9ca26c4d787a9b78105adc4b44
-      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.6.3
+      '@typescript-eslint/eslint-plugin': 5.12.1_78ba2542c270c83b2a80bb1c125195b6
+      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.5.5
       babel-eslint: 10.1.0_eslint@7.32.0
       eslint: 7.32.0
       eslint-config-prettier: 8.4.0_eslint@7.32.0
@@ -5183,7 +5183,7 @@ packages:
       '@types/yargs-parser': 20.2.1
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.12.1_75ac8a9ca26c4d787a9b78105adc4b44:
+  /@typescript-eslint/eslint-plugin/5.12.1_011f416f0b1f048c6baea22941945307:
     resolution: {integrity: sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5194,18 +5194,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.6.3
+      '@typescript-eslint/parser': 5.12.1_eslint@7.32.0+typescript@4.2.4
       '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/type-utils': 5.12.1_eslint@7.32.0+typescript@4.6.3
-      '@typescript-eslint/utils': 5.12.1_eslint@7.32.0+typescript@4.6.3
+      '@typescript-eslint/type-utils': 5.12.1_eslint@7.32.0+typescript@4.2.4
+      '@typescript-eslint/utils': 5.12.1_eslint@7.32.0+typescript@4.2.4
       debug: 4.3.3
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
+      tsutils: 3.21.0_typescript@4.2.4
+      typescript: 4.2.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5282,6 +5282,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/5.12.1_eslint@7.32.0+typescript@4.2.4:
+    resolution: {integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.12.1
+      '@typescript-eslint/types': 5.12.1
+      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.2.4
+      debug: 4.3.3
+      eslint: 7.32.0
+      typescript: 4.2.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser/5.12.1_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5298,26 +5318,6 @@ packages:
       debug: 4.3.3
       eslint: 7.32.0
       typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser/5.12.1_eslint@7.32.0+typescript@4.6.3:
-    resolution: {integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.6.3
-      debug: 4.3.3
-      eslint: 7.32.0
-      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5348,6 +5348,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils/5.12.1_eslint@7.32.0+typescript@4.2.4:
+    resolution: {integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.12.1_eslint@7.32.0+typescript@4.2.4
+      debug: 4.3.3
+      eslint: 7.32.0
+      tsutils: 3.21.0_typescript@4.2.4
+      typescript: 4.2.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/type-utils/5.12.1_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5363,25 +5382,6 @@ packages:
       eslint: 7.32.0
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils/5.12.1_eslint@7.32.0+typescript@4.6.3:
-    resolution: {integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/utils': 5.12.1_eslint@7.32.0+typescript@4.6.3
-      debug: 4.3.3
-      eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5411,6 +5411,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.12.1_typescript@4.2.4:
+    resolution: {integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.12.1
+      '@typescript-eslint/visitor-keys': 5.12.1
+      debug: 4.3.3
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.2.4
+      typescript: 4.2.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.12.1_typescript@4.5.5:
     resolution: {integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5428,27 +5449,6 @@ packages:
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree/5.12.1_typescript@4.6.3:
-    resolution: {integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/visitor-keys': 5.12.1
-      debug: 4.3.3
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.6.3
-      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5471,6 +5471,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.12.1_eslint@7.32.0+typescript@4.2.4:
+    resolution: {integrity: sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.12.1
+      '@typescript-eslint/types': 5.12.1
+      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.2.4
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/utils/5.12.1_eslint@7.32.0+typescript@4.5.5:
     resolution: {integrity: sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5481,24 +5499,6 @@ packages:
       '@typescript-eslint/scope-manager': 5.12.1
       '@typescript-eslint/types': 5.12.1
       '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.5.5
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils/5.12.1_eslint@7.32.0+typescript@4.6.3:
-    resolution: {integrity: sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.6.3
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -8369,14 +8369,14 @@ packages:
       dot-prop: 5.3.0
     dev: true
 
-  /compatfactory/0.0.12_typescript@4.6.3:
+  /compatfactory/0.0.12_typescript@4.2.4:
     resolution: {integrity: sha512-DD5S1s2mIoVIpYfhCqNZPbOFlt9JDLkXc4d8fAZaeWWIsl7w3bmVS0HNlUkU2SB6iZOdXOjYZgeJZClmL1xnRg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       typescript: '>=3.x || >= 4.x'
     dependencies:
       helpertypes: 0.0.17
-      typescript: 4.6.3
+      typescript: 4.2.4
     dev: true
 
   /component-emitter/1.3.0:
@@ -15507,7 +15507,7 @@ packages:
       terser: 5.11.0
     dev: true
 
-  /rollup-plugin-ts/2.0.5_8a4919141d01bc826ac533e6fad3b657:
+  /rollup-plugin-ts/2.0.5_a74e15baef0083ab3d8fd1c7f2ec00bb:
     resolution: {integrity: sha512-yLfu46XsheAEDs+OxCMnHszble9pYwGYDML82lpMw3x/65kgwd9UQSkPX0HZGk+6L+MN8hFgqeh+SPmv+uOz1w==}
     engines: {node: '>=10.0.0', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     peerDependencies:
@@ -15541,13 +15541,13 @@ packages:
       browserslist: 4.19.3
       browserslist-generator: 1.0.65
       chalk: 4.1.2
-      compatfactory: 0.0.12_typescript@4.6.3
+      compatfactory: 0.0.12_typescript@4.2.4
       crosspath: 1.0.0
       magic-string: 0.25.7
       rollup: 2.72.0
-      ts-clone-node: 0.3.30_typescript@4.6.3
+      ts-clone-node: 0.3.30_typescript@4.2.4
       tslib: 2.3.1
-      typescript: 4.6.3
+      typescript: 4.2.4
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -16890,14 +16890,14 @@ packages:
     resolution: {integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=}
     engines: {node: '>=0.10.0'}
 
-  /ts-clone-node/0.3.30_typescript@4.6.3:
+  /ts-clone-node/0.3.30_typescript@4.2.4:
     resolution: {integrity: sha512-T9RLibxk0UBHelLUnSIZNyTxlPzcEk+KFFLXBUAG9YFJ3gPOYRrgD/RHnrlAxwEJ9Gq5S/iB8m3tcuTKtgf5Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       typescript: ^3.x || ^4.x
     dependencies:
-      compatfactory: 0.0.12_typescript@4.6.3
-      typescript: 4.6.3
+      compatfactory: 0.0.12_typescript@4.2.4
+      typescript: 4.2.4
     dev: true
 
   /ts-node/9.1.1_typescript@4.5.5:
@@ -16942,6 +16942,16 @@ packages:
       tslib: 1.14.1
     dev: true
 
+  /tsutils/3.21.0_typescript@4.2.4:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.2.4
+    dev: true
+
   /tsutils/3.21.0_typescript@4.5.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -16950,16 +16960,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.5.5
-    dev: true
-
-  /tsutils/3.21.0_typescript@4.6.3:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.6.3
     dev: true
 
   /tty-browserify/0.0.0:
@@ -17049,7 +17049,7 @@ packages:
       typedoc: '>=0.22.9'
       typedoc-plugin-markdown: '>=3.11.10'
     dependencies:
-      typedoc: 0.22.12_typescript@4.6.4
+      typedoc: 0.22.12_typescript@4.6.3
       typedoc-plugin-markdown: 3.11.14_typedoc@0.22.12
     dev: true
 
@@ -17059,7 +17059,7 @@ packages:
       typedoc: '>=0.22.9'
       typedoc-plugin-markdown: '>=3.11.10'
     dependencies:
-      typedoc: 0.22.12_typescript@4.6.4
+      typedoc: 0.22.12_typescript@4.6.3
       typedoc-plugin-markdown: 3.11.14_typedoc@0.22.12
     dev: true
 
@@ -17073,7 +17073,7 @@ packages:
       typedoc: '>=0.22.0'
     dependencies:
       handlebars: 4.7.7
-      typedoc: 0.22.12_typescript@4.6.4
+      typedoc: 0.22.12_typescript@4.6.3
     dev: true
 
   /typedoc-plugin-mdn-links/1.0.5_typedoc@0.22.12:
@@ -17081,10 +17081,10 @@ packages:
     peerDependencies:
       typedoc: 0.22.x
     dependencies:
-      typedoc: 0.22.12_typescript@4.6.4
+      typedoc: 0.22.12_typescript@4.6.3
     dev: true
 
-  /typedoc/0.22.12_typescript@4.6.4:
+  /typedoc/0.22.12_typescript@4.6.3:
     resolution: {integrity: sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==}
     engines: {node: '>= 12.10.0'}
     hasBin: true
@@ -17096,11 +17096,17 @@ packages:
       marked: 4.0.12
       minimatch: 3.1.2
       shiki: 0.10.1
-      typescript: 4.6.4
+      typescript: 4.6.3
     dev: true
 
   /typescript-memoize/1.1.0:
     resolution: {integrity: sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==}
+
+  /typescript/4.2.4:
+    resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
 
   /typescript/4.5.5:
     resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
@@ -17110,12 +17116,6 @@ packages:
 
   /typescript/4.6.3:
     resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.6.4:
-    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Reverts NullVoxPopuli/ember-resources#434

I've added more restrictions on merging to the `main` branch due to this oversight.

It turns out, if the branch goes green before CI boots up, renovate will just merge things if nothing is blocking the PR :see_no_evil: 