### PR TITLE
fix(RemoteData, function-resource): wrapped template usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 public-hoist-pattern[]=*@types*
+
+# Required because broccoli has hard-coded paths to *all* packages
+# not just relevant ones..........
+public-hoist-pattern[]=eslint-plugin*
+public-hoist-pattern[]=eslint-config*

--- a/ember-resources/src/util/remote-data.ts
+++ b/ember-resources/src/util/remote-data.ts
@@ -109,6 +109,24 @@ export function remoteData({ on }: Hooks, url: string, options: FetchOptions = {
  * }
  * ```
  *
+ * In strict mode with <template>
+ * ```gjs
+ * import { RemoteData } from 'ember-resources/util/remote-data';
+ *
+ * const options = (token) => ({
+ *   headers: {
+ *     Authorization: `Bearer ${token}`
+ *   }
+ * });
+ *
+ * <template>
+ *  {{#let (RemoteData "https://some.domain" (options "my-token")) as |state|}}
+ *    {{state.isLoading}}
+ *    {{state.value}}
+ *  {{/let}}
+ * </template>
+ * ```
+ *
  */
 export function RemoteData(url: string, options?: FetchOptions): State;
 

--- a/ember-resources/src/util/remote-data.ts
+++ b/ember-resources/src/util/remote-data.ts
@@ -1,7 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 import { waitForPromise } from '@ember/test-waiters';
 
-import { resource } from './function-resource';
+import { registerResourceWrapper, resource } from './function-resource';
 
 import type { Hooks } from './function-resource';
 
@@ -188,3 +188,5 @@ export function RemoteData(
     return remoteData(hooks, targetUrl, options);
   });
 }
+
+registerResourceWrapper(RemoteData);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,10 +310,10 @@ importers:
       ember-try: 2.0.0
       ember-welcome-page: 6.1.0
       eslint: 7.32.0
-      eslint-config-prettier: 8.4.0_eslint@7.32.0
-      eslint-plugin-ember: 10.5.9_eslint@7.32.0
+      eslint-config-prettier: 8.5.0_eslint@7.32.0
+      eslint-plugin-ember: 10.6.1_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
-      eslint-plugin-prettier: 4.0.0_5u7oomrk4c6c4veizye6iqamma
+      eslint-plugin-prettier: 4.0.0_z7eskpggz6hgh3lpmotlmahgxe
       eslint-plugin-qunit: 7.2.0_eslint@7.32.0
       loader.js: 4.7.0
       msw: 0.39.2
@@ -9758,6 +9758,23 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
+  /eslint-plugin-prettier/4.0.0_z7eskpggz6hgh3lpmotlmahgxe:
+    resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      eslint: '>=7.28.0'
+      eslint-config-prettier: '*'
+      prettier: '>=2.0.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 7.32.0
+      eslint-config-prettier: 8.5.0_eslint@7.32.0
+      prettier: 2.5.1
+      prettier-linter-helpers: 1.0.0
+    dev: true
+
   /eslint-plugin-qunit/7.2.0_eslint@7.32.0:
     resolution: {integrity: sha512-ebT6aOpmMj4vchG0hVw9Ukbutk/lgywrc8gc9w9hH2/4WjKqwMlyM7iVwqB7OAXv6gtQMJZuziT0wNjjymAuWA==}
     engines: {node: 12.x || 14.x || >=16.0.0}
@@ -14775,7 +14792,7 @@ packages:
   /rxjs/7.5.5:
     resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: true
 
   /safe-buffer/5.1.2:

--- a/testing/ember-app/tests/utils/function-resource/rendering-test.ts
+++ b/testing/ember-app/tests/utils/function-resource/rendering-test.ts
@@ -4,7 +4,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { resource } from 'ember-resources/util/function-resource';
+import { registerResourceWrapper, resource } from 'ember-resources/util/function-resource';
 
 module('Utils | resource | rendering', function (hooks) {
   setupRenderingTest(hooks);
@@ -56,5 +56,61 @@ module('Utils | resource | rendering', function (hooks) {
       'resolve 7',
       'destroy 7',
     ]);
+  });
+
+  module('with a registered wrapper', function () {
+    test('lifecycle', async function (assert) {
+      function Wrapper(initial: number) {
+        return resource(({ on }) => {
+          on.cleanup(() => assert.step(`destroy ${initial}`));
+
+          assert.step(`resolve ${initial}`);
+
+          return initial + 1;
+        });
+      }
+
+      registerResourceWrapper(Wrapper);
+
+      class Test {
+        @tracked num = 0;
+      }
+
+      let foo = new Test();
+
+      this.setProperties({ Wrapper, foo });
+
+      await render(hbs`
+        {{#let (this.Wrapper this.foo.num) as |state|}}
+          <out>{{state}}</out>
+        {{/let}}
+      `);
+
+      assert.dom('out').containsText('1');
+
+      foo.num = 2;
+      await settled();
+
+      assert.dom('out').containsText('3');
+
+      foo.num = 7;
+      await settled();
+
+      assert.dom('out').containsText('8');
+
+      await clearRender();
+
+      /**
+       * As a reminder, destruction is async
+       */
+      assert.verifySteps([
+        'resolve 0',
+        'resolve 2',
+        'destroy 0',
+        'resolve 7',
+        'destroy 2',
+        'destroy 7',
+      ]);
+    });
   });
 });

--- a/testing/ember-app/tests/utils/remote-data/rendering-test.ts
+++ b/testing/ember-app/tests/utils/remote-data/rendering-test.ts
@@ -1,0 +1,50 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { setupMSW } from 'ember-app/tests/msw';
+import { RemoteData } from 'ember-resources/util/remote-data';
+
+let data = [
+  { id: '1', type: 'blogs', attributes: { name: `name:1` } },
+  { id: '2', type: 'blogs', attributes: { name: `name:2` } },
+  { id: '3', type: 'blogs', attributes: { name: `name:3` } },
+];
+
+module('Utils | remote-data | rendering', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMSW(hooks, ({ rest }) => [
+    rest.get('/blogs/:id', (req, res, ctx) => {
+      let record = data.find((datum) => datum.id === req.params.id);
+
+      return res(ctx.json({ ...record }));
+    }),
+  ]);
+
+  module('RemoteData', function () {
+    test('works with static url', async function (assert) {
+      this.setProperties({ RemoteData });
+
+      await render(hbs`
+        {{#let (this.RemoteData "/blogs/1") as |blog|}}
+          {{blog.value.attributes.name}}
+        {{/let}}
+      `);
+
+      assert.dom().hasText('name:1');
+    });
+
+    test('works with dynamic url', async function (assert) {
+      this.setProperties({ RemoteData });
+
+      await render(hbs`
+        {{#let (this.RemoteData "/blogs/1") as |blog|}}
+          {{blog.value.attributes.name}}
+        {{/let}}
+      `);
+
+      assert.dom().hasText('name:1');
+    });
+  });
+});


### PR DESCRIPTION
In order to use RemoteData as template-resource, we need
_another helper manager_, and we need to register it as well.
This ends up resulting in _nested_ helper-manager invocation for a
single helper-invocation call.

Resolves: https://github.com/NullVoxPopuli/ember-resources/issues/486

Todo

- [x] update docs for `RemoteData` for use in templates
- [x] update docs for `resource` for use in templates
- [x] add tests for `resource` in templates
  - [x] be sure to test lifecycle
  - [x] be sure to test the wrapper function helper - that it retains the same lifecycle behavior
- [ ] write docs for authoring addons / libraries / utilities using resources and supporting strict mode or "anything as values" mentality