### PR TITLE
fix(function-resource): lifecycle fixes

### DIFF
--- a/ember-resources/src/util/function-resource.ts
+++ b/ember-resources/src/util/function-resource.ts
@@ -1,12 +1,7 @@
 // @ts-ignore
-import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { getValue } from '@glimmer/tracking/primitives/cache';
 import { assert } from '@ember/debug';
-import {
-  associateDestroyableChild,
-  destroy,
-  registerDestructor,
-  unregisterDestructor,
-} from '@ember/destroyable';
+import { associateDestroyableChild, destroy, registerDestructor } from '@ember/destroyable';
 // @ts-ignore
 import { capabilities as helperCapabilities, invokeHelper, setHelperManager } from '@ember/helper';
 
@@ -155,26 +150,62 @@ export function resource<Value>(context: object, setup: ResourceFunction<Value>)
 export function resource<Value>(
   context: object | ResourceFunction<Value>,
   setup?: ResourceFunction<Value>
-):
-  | Value
-  | { [INTERNAL]: true; [INTERMEDIATE_VALUE]: ResourceFunction<Value> }
-  | ResourceFunction<Value> {
-  /**
-   * With only one argument, we have to do a bunch of lying to
-   * TS, because we need a special object to pass to `@use`
-   */
-  if (typeof context === 'function' && !setup) {
-    setHelperManager(() => MANAGER, context);
+): Value | InternalIntermediate<Value> | ResourceFunction<Value> {
+  if (!setup) {
+    assert(
+      `When using \`resource\` with @use, ` +
+        `the first argument to \`resource\` must be a function. ` +
+        `Instead, a ${typeof context} was received.`,
+      typeof context === 'function'
+    );
 
-    // Add secret key to help @use assert against
-    // using vanilla functions as resources without the resource wrapper
+    /**
+     * Functions have a different identity every time they are defined.
+     * The primary purpose of the `resource` wrapper is to individually
+     * register each function with our helper manager.
+     */
+    setHelperManager(ResourceManagerFactory, context);
+
+    /**
+     * With only one argument, we have to do a bunch of lying to
+     * TS, because we need a special object to pass to `@use`
+     *
+     * Add secret key to help @use assert against
+     * using vanilla functions as resources without the resource wrapper
+     */
     (context as any)[INTERNAL] = true;
 
     return context as ResourceFunction<Value>;
   }
 
-  setHelperManager(() => MANAGER, setup);
+  assert(
+    `Mismatched argument typs passed to \`resource\`. ` +
+      `Expected the first arg, the context, to be a type of object. This is usually the \`this\`. ` +
+      `Received ${typeof context} instead.`,
+    typeof context === 'object'
+  );
+  assert(
+    `Mismatched argument type passed to \`resource\`. ` +
+      `Expected the second arg to be a function but instead received ${typeof setup}.`,
+    typeof setup === 'function'
+  );
 
+  setHelperManager(ResourceManagerFactory, setup);
+
+  return wrapForPlainUsage(context, setup);
+}
+
+const INTERMEDIATE_VALUE = '__Intermediate_Value__';
+const INTERNAL = '__INTERNAL__';
+
+/**
+ * This is what allows resource to be used withotu @use.
+ * The caveat though is that a property must be accessed
+ * on the return object.
+ *
+ * A resource not using use *must* be an object.
+ */
+function wrapForPlainUsage<Value>(context: object, setup: ResourceFunction<Value>) {
   let cache: Cache;
 
   /*
@@ -186,7 +217,7 @@ export function resource<Value>(
   const target = {
     get [INTERMEDIATE_VALUE]() {
       if (!cache) {
-        cache = invokeHelper(context, setup, () => ({}));
+        cache = invokeHelper(context, setup);
       }
 
       return getValue<Value>(cache);
@@ -221,6 +252,15 @@ export function resource<Value>(
   }) as never as Value;
 }
 
+/**
+ * Secret args to allow `resource` to be used without
+ * a decorator
+ */
+interface InternalIntermediate<Value> {
+  [INTERNAL]: true;
+  [INTERMEDIATE_VALUE]: ResourceFunction<Value>;
+}
+
 export type Hooks = {
   on: {
     /**
@@ -251,13 +291,9 @@ type Destructor = () => void;
 type ResourceFunction<Value = unknown> = (hooks: Hooks) => Value;
 type Cache = object;
 
-const INTERMEDIATE_VALUE = '__Intermediate_Value__';
-const INTERNAL = '__INTERNAL__';
-
-let DESTROYERS = new WeakMap();
-
 /**
- * Note, a function-resource receives
+ * Note, a function-resource receives on object, hooks.
+ *    We have to build that manually in this helper manager
  */
 class FunctionResourceManager {
   capabilities = helperCapabilities('3.23', {
@@ -265,57 +301,47 @@ class FunctionResourceManager {
     hasDestroyable: true,
   });
 
+  constructor(protected owner: unknown) {}
+
+  /**
+   * Resources do not take args.
+   * However, they can access tracked data
+   */
   createHelper(fn: ResourceFunction) {
-    /**
-     * The helper is only created once.
-     * It's the cache's callback that is invoked multiple times,
-     * based on reactive behavior
-     *
-     */
-    let cache: Cache = createCache(() => {
-      let destroyer = DESTROYERS.get(fn);
+    let thisFn = fn.bind(null);
 
-      /**
-       * Because every function invocation shares the same cache,
-       * we gotta take care of destruction manually.
-       *
-       * Glimmer will handle the last destruction for us when it tears down the cache
-       *
-       * It is not guaranteed if destruction is async or sync, and this may change in the future if it needs to
-       */
-      if (destroyer) {
-        unregisterDestructor(fn, destroyer);
-        destroyer();
-      }
+    associateDestroyableChild(fn, thisFn);
 
-      let value = fn({
-        on: {
-          cleanup: (destroyer: Destructor) => {
-            associateDestroyableChild(cache, fn);
-            registerDestructor(fn, destroyer);
+    return thisFn;
+  }
 
-            DESTROYERS.set(fn, destroyer);
-          },
+  previousFn?: object;
+
+  getValue(fn: ResourceFunction) {
+    if (this.previousFn) {
+      destroy(this.previousFn);
+    }
+
+    let currentFn = fn.bind(null);
+
+    associateDestroyableChild(fn, currentFn);
+    this.previousFn = currentFn;
+
+    return currentFn({
+      on: {
+        cleanup: (destroyer: Destructor) => {
+          registerDestructor(currentFn, destroyer);
         },
-      });
-
-      return value;
+      },
     });
-
-    return cache;
   }
 
-  getValue(cache: Cache) {
-    return getValue(cache);
-  }
-
-  getDestroyable(cache: Cache) {
-    return cache;
+  getDestroyable(fn: ResourceFunction) {
+    return fn;
   }
 }
 
 type ResourceFactory = (...args: any[]) => ReturnType<typeof resource>;
-type InvokerState = { fn: ResourceFactory; args: any };
 
 class ResourceInvokerManager {
   capabilities = helperCapabilities('3.23', {
@@ -323,38 +349,27 @@ class ResourceInvokerManager {
     hasDestroyable: true,
   });
 
-  helper?: object;
+  constructor(protected owner: unknown) {}
 
-  createHelper(fn: ResourceFactory, args: any): InvokerState {
-    return createCache(() => {
-      return fn(...args.positional);
-    });
+  createHelper(fn: ResourceFactory, args: any): Cache {
+    return { fn, args };
   }
 
-  getValue(cache: Cache) {
-    if (this.helper) {
-      destroy(this.helper);
-    }
-
-    let helper = getValue(cache);
-
-    let result = invokeHelper(this, helper, () => ({}));
-
-    associateDestroyableChild(cache, helper);
-
-    this.helper = helper;
+  getValue({ fn, args }: { fn: ResourceFactory; args: any }) {
+    let helper = fn(...args.positional) as object;
+    let result = invokeHelper(this, helper);
 
     return getValue(result);
   }
 
-  getDestroyable(cache: Cache) {
-    return cache;
+  getDestroyable({ fn }: { fn: ResourceFactory }) {
+    return fn;
   }
 }
 
 // Provide a singleton manager.
-const MANAGER = new FunctionResourceManager();
-const ResourceInvoker = new ResourceInvokerManager();
+const ResourceManagerFactory = (owner: unknown) => new FunctionResourceManager(owner);
+const ResourceInvokerFactory = (owner: unknown) => new ResourceInvokerManager(owner);
 
 /**
  * Allows wrapper functions to provide a [[resource]] for use in templates.
@@ -367,9 +382,9 @@ const ResourceInvoker = new ResourceInvokerManager();
  *
  *  Example using strict mode + <template> syntax and a template-only component:
  *  ```js
- *  import { resource, registerResourceWrapper } from 'ember-resources/util/function-resource';
+ *  import { resource, resourceFactory } from 'ember-resources/util/function-resource';
  *
- *  function RemoteData(url) {
+ *  const RemoteData = resourceFactory((url) => {
  *    return resource(({ on }) => {
  *      let state = new TrackedObject({});
  *      let controller = new AbortController();
@@ -387,12 +402,10 @@ const ResourceInvoker = new ResourceInvokerManager();
  *
  *      return state;
  *    })
- * }
- *
- * registerResourceWrapper(RemoteData)
+ * });
  *
  *  <template>
- *    {{#let (load) as |state|}}
+ *    {{#let (RemoteData) as |state|}}
  *      {{#if state.value}}
  *        ...
  *      {{else if state.error}}
@@ -402,21 +415,26 @@ const ResourceInvoker = new ResourceInvokerManager();
  *  </template>
  *  ```
  *
- *  Alternatively, `registerResourceWrapper` can wrap the wrapper function.
+ *  Alternatively, `resourceFactory` can wrap the wrapper function.
  *
  *  ```js
- *  const RemoteData = registerResourceWrapper((url) => {
+ *  const RemoteData = resourceFactory((url) => {
  *    return resource(({ on }) => {
  *      ...
  *    });
  *  })
  *  ```
  */
-export function registerResourceWrapper(wrapperFn: ResourceFactory) {
-  setHelperManager(() => ResourceInvoker, wrapperFn);
+export function resourceFactory(wrapperFn: ResourceFactory) {
+  setHelperManager(ResourceInvokerFactory, wrapperFn);
 
   return wrapperFn;
 }
+
+/**
+ * @deprecated - use resourceFactory (same behavior, just renamed)
+ */
+export const registerResourceWrapper = resourceFactory;
 
 interface Descriptor {
   initializer: () => unknown;
@@ -458,8 +476,8 @@ export function use(_prototype: object, key: string, descriptor?: Descriptor): v
 
   // https://github.com/pzuraq/ember-could-get-used-to-this/blob/master/addon/index.js
   return {
-    get() {
-      let cache = caches.get(this as object);
+    get(this: object) {
+      let cache = caches.get(this);
 
       if (!cache) {
         let fn = initializer.call(this);
@@ -469,7 +487,7 @@ export function use(_prototype: object, key: string, descriptor?: Descriptor): v
           isResourceInitializer(fn)
         );
 
-        cache = invokeHelper(this, fn, () => ({}));
+        cache = invokeHelper(this, fn);
 
         caches.set(this as object, cache);
       }

--- a/ember-resources/src/util/remote-data.ts
+++ b/ember-resources/src/util/remote-data.ts
@@ -1,7 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 import { waitForPromise } from '@ember/test-waiters';
 
-import { registerResourceWrapper, resource } from './function-resource';
+import { resource, resourceFactory } from './function-resource';
 
 import type { Hooks } from './function-resource';
 
@@ -237,4 +237,4 @@ export function RemoteData(
   });
 }
 
-registerResourceWrapper(RemoteData);
+resourceFactory(RemoteData);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "NullVoxPopuli",
   "scripts": {
     "dev": "concurrently 'npm:dev:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-    "dev:ember": "pnpm run --filter ember-app start --port 0",
+    "dev:ember": "pnpm run --filter ember-app start",
     "dev:addon": "pnpm run --filter ember-resources start --no-watch.clearScreen",
     "dev:docs": "pnpm run --filter docs docs:watch --preserveWatchOutput",
     "ci:update": "npx ember-ci-update",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,7 @@ importers:
       prettier: ^2.3.2
       qunit: ^2.16.0
       qunit-dom: ^2.0.0
+      tracked-built-ins: ^3.1.0
       typescript: '4.2'
       webpack: ^5.72.1
     dependencies:
@@ -230,6 +231,7 @@ importers:
       ember-concurrency-ts: 0.3.1_ember-concurrency@2.2.1
       ember-functions-as-helper-polyfill: 2.0.1
       ember-resources: link:../../ember-resources
+      tracked-built-ins: 3.1.0
     devDependencies:
       '@babel/core': 7.18.0
       '@ember/optional-features': 2.0.0
@@ -599,7 +601,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.17.10
-      '@babel/core': 7.18.0
+      '@babel/core': 7.18.0_supports-color@8.1.1
       '@babel/helper-validator-option': 7.16.7
       browserslist: 4.20.3
       semver: 6.3.0
@@ -9690,6 +9692,24 @@ packages:
       - supports-color
     dev: false
 
+  /ember-cli-typescript/5.1.0:
+    resolution: {integrity: sha512-wEZfJPkjqFEZAxOYkiXsDrJ1HY75e/6FoGhQFg8oNFJeGYpIS/3W0tgyl1aRkSEEN1NRlWocDubJ4aZikT+RTA==}
+    engines: {node: '>= 12.*'}
+    dependencies:
+      ansi-to-html: 0.6.15
+      broccoli-stew: 3.0.0
+      debug: 4.3.4
+      execa: 4.1.0
+      fs-extra: 9.1.0
+      resolve: 1.22.0
+      rsvp: 4.8.5
+      semver: 7.3.7
+      stagehand: 1.0.0
+      walk-sync: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ember-cli-valid-component-name/1.0.0:
     resolution: {integrity: sha1-cVUM44fgIzBl8wswsVEKot++h+8=}
     dependencies:
@@ -10327,6 +10347,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /ember-tracked-storage-polyfill/1.0.0:
+    resolution: {integrity: sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==}
+    engines: {node: 12.* || >= 14}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /ember-try-config/4.0.0:
     resolution: {integrity: sha512-jAv7fqYJK7QYYekPc/8Nr7KOqDpv/asqM6F8xcRnbmf9UrD35BkSffY63qUuiD9e0aR5qiMNBIQzH8f65rGDqw==}
@@ -13162,7 +13192,7 @@ packages:
     dev: true
 
   /is-stream/1.1.0:
-    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=}
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -14656,7 +14686,7 @@ packages:
     dev: true
 
   /npm-run-path/2.0.2:
-    resolution: {integrity: sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=}
+    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
     engines: {node: '>=4'}
     dependencies:
       path-key: 2.0.1
@@ -14846,12 +14876,12 @@ packages:
     dev: true
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
 
   /onetime/2.0.1:
-    resolution: {integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=}
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
     engines: {node: '>=4'}
     dependencies:
       mimic-fn: 1.2.0
@@ -17592,6 +17622,17 @@ packages:
       punycode: 2.1.1
     dev: true
 
+  /tracked-built-ins/3.1.0:
+    resolution: {integrity: sha512-yPEZV1aYaw7xFWdoEluvdwNxIJIA834HaBQaMATjNAYPwd1fRqIJ46YnuRo6+9mRRWu6nM6sJqrVVa5H6UhFuw==}
+    engines: {node: 14.* || 16.* || >= 18.*}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-typescript: 5.1.0
+      ember-tracked-storage-polyfill: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /traverse/0.6.6:
     resolution: {integrity: sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=}
     dev: true
@@ -18163,7 +18204,7 @@ packages:
     dev: true
 
   /walk-sync/0.2.7:
-    resolution: {integrity: sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=}
+    resolution: {integrity: sha512-OH8GdRMowEFr0XSHQeX5fGweO6zSVHo7bG/0yJQx6LAj9Oukz0C8heI3/FYectT66gY0IPGe89kOvU410/UNpg==}
     dependencies:
       ensure-posix-path: 1.1.1
       matcher-collection: 1.1.2
@@ -18542,7 +18583,7 @@ packages:
     dev: true
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}

--- a/testing/ember-app/app/config/environment.d.ts
+++ b/testing/ember-app/app/config/environment.d.ts
@@ -11,4 +11,5 @@ declare const config: {
   locationType: 'history' | 'hash' | 'none' | 'auto';
   rootURL: string;
   APP: Record<string, unknown>;
+  isTestCli: boolean | undefined;
 };

--- a/testing/ember-app/config/environment.js
+++ b/testing/ember-app/config/environment.js
@@ -1,5 +1,7 @@
 'use strict';
 
+let isTestCli = process.argv.includes('test');
+
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'ember-app',
@@ -21,6 +23,8 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+
+    isTestCli,
   };
 
   if (environment === 'development') {

--- a/testing/ember-app/package.json
+++ b/testing/ember-app/package.json
@@ -33,7 +33,8 @@
     "ember-concurrency": "^2.0.0",
     "ember-concurrency-ts": "^0.3.1",
     "ember-functions-as-helper-polyfill": "^2.0.1",
-    "ember-resources": "*"
+    "ember-resources": "*",
+    "tracked-built-ins": "^3.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/testing/ember-app/tests/msw.ts
+++ b/testing/ember-app/tests/msw.ts
@@ -1,5 +1,6 @@
 import * as QUnit from 'qunit';
 
+import ENV from 'ember-app/config/environment';
 import { rest, setupWorker } from 'msw';
 
 import type { SetupWorkerApi } from 'msw';
@@ -19,7 +20,7 @@ QUnit.begin(async () => {
    * At this point we have no request handlers, but that's what
    * setupMSW is for
    */
-  await worker.start();
+  await worker.start({ quiet: ENV.isTestCli });
 });
 
 QUnit.done(async () => {

--- a/testing/ember-app/tests/utils/function-resource/rendering-test.ts
+++ b/testing/ember-app/tests/utils/function-resource/rendering-test.ts
@@ -1,11 +1,13 @@
 import { tracked } from '@glimmer/tracking';
 import { destroy } from '@ember/destroyable';
-import { clearRender, render, settled } from '@ember/test-helpers';
+import { clearRender, find, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { resource, use } from 'ember-resources/util/function-resource';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
+import { resource, resourceFactory, use } from 'ember-resources/util/function-resource';
+import { TrackedObject } from 'tracked-built-ins';
 
 module('Utils | resource | rendering', function (hooks) {
   setupRenderingTest(hooks);
@@ -384,6 +386,57 @@ module('Utils | resource | rendering', function (hooks) {
     });
   });
 
+  module('persistent state', function () {
+    test('a clock can keep time', async function (assert) {
+      // timeout is too new for the types to know about
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      assert.timeout(3000);
+
+      const clock = resource(({ on }) => {
+        let time = new TrackedObject({ current: new Date() });
+        let interval = setInterval(() => {
+          time.current = new Date();
+        }, 1000);
+
+        on.cleanup(() => clearInterval(interval));
+
+        let now = time.current;
+
+        return new Intl.DateTimeFormat('en-US', {
+          hour: 'numeric',
+          minute: 'numeric',
+          second: 'numeric',
+          hour12: false,
+        }).format(now);
+      });
+
+      this.setProperties({ clock });
+
+      await render(hbs`
+        <time>{{this.clock}}</time>
+      `);
+
+      let textA = find('time')?.innerText;
+
+      assert.ok(textA, textA);
+
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      let textB = find('time')?.innerText;
+
+      assert.ok(textB, textB);
+      assert.notStrictEqual(textA, textB, `${textB} is 1s after ${textA}`);
+
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      let textC = find('time')?.innerText;
+
+      assert.ok(textC, textC);
+      assert.notStrictEqual(textB, textC, `${textC} is 1s after ${textB}`);
+    });
+  });
+
   module('with a wrapper', function () {
     test('lifecycle', async function (assert) {
       const Wrapper = (initial: number) => {
@@ -435,6 +488,79 @@ module('Utils | resource | rendering', function (hooks) {
         'destroy 2',
         'destroy 7',
       ]);
+    });
+
+    module('persistent state', function () {
+      test('a Clock can keep time', async function (assert) {
+        // timeout is too new for the types to know about
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        assert.timeout(3000);
+
+        // Wrapper functions are the only way to pass Args to a resource.
+        const Clock = resourceFactory(({ start, locale = 'en-US' }) => {
+          // For a persistent state across arg changes, `Resource` may be better`
+          let time = new TrackedObject({ current: start });
+
+          return resource(({ on }) => {
+            let interval = setInterval(() => {
+              time.current = new Date();
+            }, 1000);
+
+            on.cleanup(() => clearInterval(interval));
+
+            return new Intl.DateTimeFormat(locale, {
+              hour: 'numeric',
+              minute: 'numeric',
+              second: 'numeric',
+              hour12: false,
+            }).format(time.current);
+          });
+        });
+
+        this.setProperties({ Clock, date: new Date(), locale: 'en-US' });
+
+        /**
+         * Older ember had a bug where nested helpers were not invoked
+         * when using a dynamic helper (this.Clock)
+         */
+        if (macroCondition(dependencySatisfies('ember-source', '~3.25.0 || ~3.26.0'))) {
+          await render(hbs`
+            <time>
+              {{#let (hash start=this.date locale=this.locale) as |options|}}
+                {{this.Clock options}}
+              {{/let}}
+            </time>
+          `);
+        } else {
+          await render(hbs`
+            <time>{{this.Clock (hash start=this.date locale=this.locale)}}</time>
+          `);
+        }
+
+        let textA = find('time')?.innerText;
+
+        assert.ok(textA, textA);
+
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+
+        let textB = find('time')?.innerText;
+
+        assert.ok(textB, textB);
+        assert.notStrictEqual(textA, textB, `${textB} is 1s after ${textA}`);
+
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+
+        let textC = find('time')?.innerText;
+
+        assert.ok(textC, textC);
+        assert.notStrictEqual(textB, textC, `${textC} is 1s after ${textB}`);
+
+        this.setProperties({ locale: 'en-CA' });
+        await settled();
+
+        assert.strictEqual(textA, find('time')?.innerText, 'Time is reset');
+      });
     });
   });
 });


### PR DESCRIPTION
Resolves an issue where, when a function-resource is directly used in a template,
the lifecycle of invoking and running cleanup was incorrect when wrapped
in an if statement (or any conditional rendering situation).  Now, when
a resource used within `{{ ... }}` is removed from the render tree, the
cleanup hook will run.