### PR TITLE
fix(package): @glint/template can't be an 'optional' peerDependency -…

### DIFF
--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -99,9 +99,6 @@
     "@glimmer/component": {
       "optional": true
     },
-    "@glint/template": {
-      "optional": true
-    },
     "ember-concurrency": {
       "optional": true
     },


### PR DESCRIPTION
… it is required