### PR TITLE
chore(docs): Fix typo in `map` example

### DIFF
--- a/ember-resources/src/util/map.ts
+++ b/ember-resources/src/util/map.ts
@@ -143,7 +143,7 @@ export interface MappedArray<MappedTo> {
  * @example
  *
  * ```js
- *  import { map } from 'ember-resources/utils/map';
+ *  import { map } from 'ember-resources/util/map';
  *
  *  class MyClass {
  *    wrappedRecords = map(this, {


### PR DESCRIPTION
Fixes a typo in the import location for one of the examples for the `map` util.