### PR TITLE
feat: Provide index to map function

### DIFF
--- a/ember-resources/src/util/map.ts
+++ b/ember-resources/src/util/map.ts
@@ -173,7 +173,7 @@ export function map<Element = unknown, MapTo = unknown>(
      * - if iterating over part of the data, map will only be called for the elements observed
      * - if not iterating, map will only be called for the elements observed.
      */
-    map: (element: Element) => MapTo;
+    map: (element: Element, index: number) => MapTo;
   }
 ) {
   let { data, map } = options;
@@ -231,7 +231,7 @@ export class TrackedArrayMap<Element = unknown, MappedTo = unknown>
   #map = new WeakMap<Element & object, MappedTo>();
 
   @tracked private declare _records: (Element & object)[];
-  @tracked private declare _map: (element: Element) => MappedTo;
+  @tracked private declare _map: (element: Element, index: number) => MappedTo;
 
   modify([data]: PositionalArgs<Element>, { map }: NamedArgs<Element, MappedTo>) {
     assert(
@@ -280,7 +280,7 @@ export class TrackedArrayMap<Element = unknown, MappedTo = unknown>
     let value = this.#map.get(record);
 
     if (!value) {
-      value = this._map(record);
+      value = this._map(record, i);
       this.#map.set(record, value);
     }
 

--- a/testing/ember-app/tests/type-tests/util/map.ts
+++ b/testing/ember-app/tests/type-tests/util/map.ts
@@ -3,8 +3,9 @@ import { expectType } from 'ts-expect';
 
 export const a = map(globalThis, {
   data: () => [1, 2, 3],
-  map: (element) => {
+  map: (element, index) => {
     expectType<number>(element);
+    expectType<number>(index);
 
     return element;
   },

--- a/testing/ember-app/tests/utils/map/js-test.ts
+++ b/testing/ember-app/tests/utils/map/js-test.ts
@@ -9,7 +9,7 @@ module('Utils | map | js', function (hooks) {
   setupTest(hooks);
 
   class Wrapper {
-    constructor(public record: unknown) {}
+    constructor(public record: unknown, public index: number) {}
   }
 
   interface TestRecord {
@@ -40,10 +40,10 @@ module('Utils | map | js', function (hooks) {
 
           return this.records;
         },
-        map: (record) => {
+        map: (record, index) => {
           assert.step(`perform map on ${record.id}`);
 
-          return new Wrapper(record);
+          return new Wrapper(record, index);
         },
       });
     }
@@ -81,6 +81,8 @@ module('Utils | map | js', function (hooks) {
 
     assert.strictEqual(currentStuff[0].record, first, 'object equality retained');
     assert.strictEqual(currentStuff[1].record, second, 'object equality retained');
+    assert.strictEqual(currentStuff[0].index, 0, 'index is correct');
+    assert.strictEqual(currentStuff[1].index, 1, 'index is correct');
 
     instance.records = [...instance.records, testData(3)];
     assert.strictEqual(instance.stuff.length, 3, 'length adjusted');


### PR DESCRIPTION
This updates the `map` utility so that it passes the index of the
element as a second argument to the given `map` function.

For example:

```js
import { map } from 'ember-resources/util/map';

class MyClass {
  wrappedRecords = map(this, {
    data: () => this.records,
    map: (record, index) => new SomeWrapper(record, index),
  }),
}
```