### PR TITLE
fix(cell): improve typings of the cell utility

### DIFF
--- a/ember-resources/src/util/cell.ts
+++ b/ember-resources/src/util/cell.ts
@@ -1,13 +1,15 @@
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 
-class Cell<T> {
-  @tracked current: T | undefined;
+class Cell<Value = unknown> {
+  @tracked declare current: Value;
 
   constructor();
-  constructor(initialValue: T);
-  constructor(initialValue?: T) {
-    this.current = initialValue;
+  constructor(initialValue: Value);
+  constructor(initialValue?: Value) {
+    if (initialValue !== undefined) {
+      this.current = initialValue;
+    }
   }
 
   toggle = () => {
@@ -54,8 +56,8 @@ class Cell<T> {
  * </template>
  * ```
  */
-export function cell<T>(initialValue?: T): Cell<T> {
-  if (initialValue) {
+export function cell<Value = unknown>(initialValue?: Value): Cell<Value> {
+  if (initialValue !== undefined) {
     return new Cell(initialValue);
   }
 

--- a/testing/ember-app/tests/utils/cell/rendering-test.gts
+++ b/testing/ember-app/tests/utils/cell/rendering-test.gts
@@ -1,5 +1,4 @@
 import { render, settled } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
@@ -9,18 +8,27 @@ module('Utils | cell | rendering', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it works', async function (assert) {
-    let state = cell();
+    let state = cell<string | undefined>();
 
-    this.setProperties({ state });
-
-    await render(hbs`{{this.state.current}}`);
+    await render(<template>{{state.current}}</template>);
 
     assert.dom().doesNotContainText('hello');
 
     state.current = 'hello';
+    await settled();
+    assert.dom().hasText('hello');
+  });
 
+  test('it works with an initial value', async function (assert) {
+    let state = cell(0);
+
+    await render(<template>{{state.current}}</template>);
+
+    assert.dom().hasText('0');
+
+    state.current++;
     await settled();
 
-    assert.dom().hasText('hello');
+    assert.dom().hasText('1');
   });
 });


### PR DESCRIPTION
in typescript / glint,  `cell` will now infer the type.
when you use `cell` with no initial value, you'll want to explicitly declare the type, as is demonstrated in the `it works` cell rendering test 