### PR TITLE
Fix isEmpty logic in keepLatest

### DIFF
--- a/ember-resources/src/util/keep-latest.ts
+++ b/ember-resources/src/util/keep-latest.ts
@@ -8,10 +8,10 @@ const isEmpty = (x: undefined | unknown | unknown[]) => {
   if (typeof x === 'object') {
     if (x === null) return true;
 
-    return x || Object.keys(x).length > 0;
+    return Object.keys(x).length === 0;
   }
 
-  return Boolean(x);
+  return x !== 0 && !x;
 };
 
 interface Options<T = unknown> {

--- a/testing/ember-app/tests/utils/keep-latest/js-test.ts
+++ b/testing/ember-app/tests/utils/keep-latest/js-test.ts
@@ -10,7 +10,7 @@ import { keepLatest } from 'ember-resources/util/keep-latest';
 module('Utils | keepLatest | js', function (hooks) {
   setupTest(hooks);
 
-  test('it works', async function (assert) {
+  test('it works with a trackedFunction', async function (assert) {
     class Test {
       @tracked x = 1;
 
@@ -44,5 +44,146 @@ module('Utils | keepLatest | js', function (hooks) {
     assert.strictEqual(instance.data, 1);
     await timeout(40);
     assert.strictEqual(instance.data, 2);
+  });
+
+  test('it works if the value gets reset to undefined while loading', async function (assert) {
+    class Test {
+      @tracked isLoading = false;
+      @tracked value?: number = 3;
+
+      @use data = keepLatest({
+        when: () => this.isLoading,
+        value: () => this.value,
+      });
+    }
+
+    let instance = new Test();
+
+    assert.strictEqual(instance.data, 3);
+
+    instance.isLoading = true;
+    instance.value = undefined;
+
+    assert.strictEqual(instance.data, 3);
+  });
+
+  test('it works with array values correctly', async function (assert) {
+    class Test {
+      @tracked isLoading = false;
+      @tracked value = ['a'];
+
+      @use data = keepLatest({
+        when: () => this.isLoading,
+        value: () => this.value,
+      });
+    }
+
+    let instance = new Test();
+
+    assert.deepEqual(instance.data, ['a']);
+
+    instance.isLoading = true;
+
+    instance.value = ['b'];
+
+    assert.deepEqual(instance.data, ['b'], 'still returns the current value if it is not empty');
+
+    instance.value = [];
+
+    assert.deepEqual(
+      instance.data,
+      ['b'],
+      'returns the previous value if the current value is empty'
+    );
+  });
+
+  test('it works with object values correctly', async function (assert) {
+    class Test {
+      @tracked isLoading = false;
+      @tracked value: Record<string, unknown> = { x: 3 };
+
+      @use data = keepLatest({
+        when: () => this.isLoading,
+        value: () => this.value,
+      });
+    }
+
+    let instance = new Test();
+
+    assert.deepEqual(instance.data, { x: 3 });
+
+    instance.isLoading = true;
+
+    instance.value = { y: 4 };
+
+    assert.deepEqual(instance.data, { y: 4 }, 'still returns the current value if it is not empty');
+
+    instance.value = {};
+
+    assert.deepEqual(
+      instance.data,
+      { y: 4 },
+      'returns the previous value if the current value is empty'
+    );
+  });
+
+  test('it works with string values correctly', async function (assert) {
+    class Test {
+      @tracked isLoading = false;
+      @tracked value = 'one';
+
+      @use data = keepLatest({
+        when: () => this.isLoading,
+        value: () => this.value,
+      });
+    }
+
+    let instance = new Test();
+
+    assert.deepEqual(instance.data, 'one');
+
+    instance.isLoading = true;
+
+    instance.value = 'two';
+
+    assert.deepEqual(instance.data, 'two', 'still returns the current value if it is not empty');
+
+    instance.value = '';
+
+    assert.deepEqual(
+      instance.data,
+      'two',
+      'returns the previous value if the current value is empty'
+    );
+  });
+
+  test('it works with number values correctly', async function (assert) {
+    class Test {
+      @tracked isLoading = false;
+      @tracked value: number | null = 1;
+
+      @use data = keepLatest({
+        when: () => this.isLoading,
+        value: () => this.value,
+      });
+    }
+
+    let instance = new Test();
+
+    assert.deepEqual(instance.data, 1);
+
+    instance.isLoading = true;
+
+    instance.value = 2;
+
+    assert.deepEqual(instance.data, 2, 'still returns the current value if it is not empty');
+
+    instance.value = 0;
+
+    assert.deepEqual(instance.data, 0, 'does not treat 0 as empty');
+
+    instance.value = null;
+
+    assert.deepEqual(instance.data, 0, 'returns the previous value if the current value is null');
   });
 });


### PR DESCRIPTION
The logic for calculating `isEmpty` was incorrect for a few cases. 

It needs to return true for:

- empty arrays
- objects that are either null or have no keys (was opposite)
- any other value that is falsey (was opposite. Also accounting for 0 now)

See updated tests for the various cases