### PR TITLE
[Blocked]: do not compile away properties and methods

### DIFF
--- a/ember-resources/babel.config.cjs
+++ b/ember-resources/babel.config.cjs
@@ -21,14 +21,5 @@ module.exports = {
         version: 'legacy',
       },
     ],
-    // Properties plugin is required by ember-cli-babel
-    // because ember-cli-babel is buggy
-    [
-      resolve('@babel/plugin-proposal-class-properties'),
-      {
-        // The stage 1 implementation
-        version: 'legacy',
-      },
-    ],
   ],
 };

--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -140,6 +140,8 @@
     "@types/ember__runloop": "^4.0.1",
     "@types/ember__test-helpers": "^2.0.0",
     "babel-eslint": "10.1.0",
+    "browserslist": "^4.21.3",
+    "caniuse-lite": "^1.0.30001393",
     "ember-async-data": "^0.6.0",
     "ember-template-lint": "3.16.0",
     "eslint": "^7.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,8 @@ importers:
       '@types/ember__runloop': ^4.0.1
       '@types/ember__test-helpers': ^2.0.0
       babel-eslint: 10.1.0
+      browserslist: ^4.21.3
+      caniuse-lite: ^1.0.30001393
       ember-async-data: ^0.6.0
       ember-template-lint: 3.16.0
       eslint: ^7.32.0
@@ -135,6 +137,8 @@ importers:
       '@types/ember__runloop': 4.0.1
       '@types/ember__test-helpers': 2.6.1
       babel-eslint: 10.1.0_eslint@7.32.0
+      browserslist: 4.21.3
+      caniuse-lite: 1.0.30001393
       ember-async-data: 0.6.0_@babel+core@7.19.0
       ember-template-lint: 3.16.0
       eslint: 7.32.0
@@ -513,7 +517,7 @@ packages:
       '@babel/compat-data': 7.19.0
       '@babel/core': 7.19.0
       '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.20.4
+      browserslist: 4.21.3
       semver: 6.3.0
 
   /@babel/helper-compilation-targets/7.19.0_@babel+core@7.19.0:
@@ -525,7 +529,7 @@ packages:
       '@babel/compat-data': 7.19.0
       '@babel/core': 7.19.0
       '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.20.4
+      browserslist: 4.21.3
       semver: 6.3.0
 
   /@babel/helper-create-class-features-plugin/7.18.0_@babel+core@7.19.0:
@@ -6716,7 +6720,7 @@ packages:
       '@types/semver': 7.3.10
       '@types/ua-parser-js': 0.7.36
       browserslist: 4.20.2
-      caniuse-lite: 1.0.30001358
+      caniuse-lite: 1.0.30001393
       isbot: 3.4.5
       object-path: 0.11.8
       semver: 7.3.7
@@ -6736,10 +6740,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001358
-      electron-to-chromium: 1.4.164
+      caniuse-lite: 1.0.30001393
+      electron-to-chromium: 1.4.247
       escalade: 3.1.1
-      node-releases: 2.0.5
+      node-releases: 2.0.6
       picocolors: 1.0.0
     dev: true
 
@@ -6753,6 +6757,16 @@ packages:
       escalade: 3.1.1
       node-releases: 2.0.5
       picocolors: 1.0.0
+
+  /browserslist/4.21.3:
+    resolution: {integrity: sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001393
+      electron-to-chromium: 1.4.247
+      node-releases: 2.0.6
+      update-browserslist-db: 1.0.7_browserslist@4.21.3
 
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -6900,6 +6914,9 @@ packages:
 
   /caniuse-lite/1.0.30001358:
     resolution: {integrity: sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==}
+
+  /caniuse-lite/1.0.30001393:
+    resolution: {integrity: sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA==}
 
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -7622,7 +7639,7 @@ packages:
   /core-js-compat/3.23.2:
     resolution: {integrity: sha512-lrgZvxFwbQp9v7E8mX0rJ+JX7Bvh4eGULZXA1IAyjlsnWvCdw6TF8Tg6xtaSUSJMrSrMaLdpmk+V54LM1dvfOA==}
     dependencies:
-      browserslist: 4.20.4
+      browserslist: 4.21.3
       semver: 7.0.0
 
   /core-js/2.6.12:
@@ -8167,6 +8184,9 @@ packages:
 
   /electron-to-chromium/1.4.164:
     resolution: {integrity: sha512-K7iy5y6XyP9Pzh3uaDti0KC4JUNT6T1tLG5RTOmesqq2YgAJpYYYJ32m+anvZYjCV35llPTEh87kvEV/uSsiyQ==}
+
+  /electron-to-chromium/1.4.247:
+    resolution: {integrity: sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw==}
 
   /elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -13145,6 +13165,9 @@ packages:
   /node-releases/2.0.5:
     resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==}
 
+  /node-releases/2.0.6:
+    resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
+
   /node-watch/0.7.3:
     resolution: {integrity: sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==}
     engines: {node: '>=6'}
@@ -14654,7 +14677,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       '@wessberg/stringutil': 1.0.19
       ansi-colors: 4.1.3
-      browserslist: 4.20.4
+      browserslist: 4.21.3
       browserslist-generator: 1.0.66
       compatfactory: 1.0.1_typescript@4.8.2
       crosspath: 2.0.0
@@ -16443,6 +16466,16 @@ packages:
     engines: {node: '>=4'}
     dev: true
     optional: true
+
+  /update-browserslist-db/1.0.7_browserslist@4.21.3:
+    resolution: {integrity: sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.3
+      escalade: 3.1.1
+      picocolors: 1.0.0
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION
This should be tested with a couple consumers before merge, this _could_ be considered a breaking change if consumers are not expecting to have to compile away private fields / methods or class fields / methods entirely. I think ember-cli-babel will handle this for them tho.

This is **BLOCKED** until this is resolved:
 - https://github.com/babel/babel/issues/14917#issuecomment-1242762773
   atm, babel compiles in a runtime error if the class-properties transform hasn't ran.
 - Once the above is resolved, this issue should also be able to be closed:
   https://github.com/babel/ember-cli-babel/issues/447

Did some math in a googlesheet: https://docs.google.com/spreadsheets/d/12k6wnuvE4peVqQRMGFHCYq3fXgx5tsadlyPIolEQKnY/edit?usp=sharing


Improvement by not compiling away properties and methods |   |   |   |  
-- | -- | -- | -- | --
  | js | min | min + gzip | min + brotli
/index.js | -5.21% | -5.54% | -1.52% | -2.63%
├── core/class-based/index.js | -8.85% | -6.82% | -6.90% | -7.40%
├── core/function-based/index.js | -6.95% | 0.00% | 0.00% | 0.00%
└── core/use.js | 0.00% | 0.00% | 0.00% | 0.00%
/util/cell.js | -8.74% | -21.21% | -10.51% | -12.34%
/util/debounce.js | -3.13% | -9.05% | -7.09% | -5.92%
/util/ember-concurrency.js | -2.35% | -8.51% | -7.48% | -7.59%
/util/function-resource.js | 0.00% | 0.00% | 0.00% | 0.00%
/util/function.js | -4.40% | -9.88% | -5.24% | -4.57%
/util/helper.js | 0.00% | 0.00% | 0.00% | 0.00%
/util/keep-latest.js | 0.00% | 0.00% | 0.00% | 0.00%
/util/map.js | -31.26% | -67.61% | -42.88% | -42.59%
/util/remote-data.js | 0.00% | -10.76% | -6.31% | -5.52%


