### PR TITLE
Drop older TS as Glint doesn't support it

### DIFF
--- a/.changeset/curvy-frogs-sin.md
+++ b/.changeset/curvy-frogs-sin.md
@@ -1,5 +1,5 @@
 ---
-"ember-resources": patch
+"ember-resources": major
 ---
 
-Support TypeScript 4.8 and 4.9
+Drop support for TypeScript < 4.8

--- a/.changeset/curvy-frogs-sin.md
+++ b/.changeset/curvy-frogs-sin.md
@@ -1,0 +1,5 @@
+---
+"ember-resources": patch
+---
+
+Support TypeScript 4.8 and 4.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
       fail-fast: true
       matrix:
         typescript-scenario:
-          - typescript@4.5
-          - typescript@4.6
-          - typescript@4.7
           - typescript@4.8
           - typescript@4.9
 


### PR DESCRIPTION
Requires: https://github.com/NullVoxPopuli/ember-resources/pull/714


TODO:
- read through https://github.com/emberjs/rfcs/pull/730 to determine what should be the semver impacts here