### PR TITLE
Fix polling helper example in CHANGELOG

### DIFF
--- a/ember-resources/CHANGELOG.md
+++ b/ember-resources/CHANGELOG.md
@@ -35,21 +35,22 @@
 
   ```ts
   import Component from "@glimmer/component";
-  import Helper from "@ember/component/helper";
   import type RouterService from "@ember/routing/router-service";
+  import { helper } from "@ember/component/helper";
   import { service } from "@ember/service";
 
-  class Poll extends Helper {
-    compute([fn, interval]: [(...args: unknown[]) => unknown, number]) {
-      let x = setInterval(fn, interval);
-      registerDestructor(this, () => clearInterval(x));
-    }
-  }
-
+  const intervals = new WeakMap();
+  
   export default class Demo extends Component {
     @service declare router: RouterService;
 
-    poll = Poll;
+    poll = helper(function ([fn, interval]: [(...args: unknown[]) => unknown, number]) {
+      if (!intervals.has(this))
+        registerDestructor(this, () => clearInterval(intervals.get(this)));
+      clearInterval(intervals.get(this);
+      intervals.set(this, setInterval(fn, interval));
+    });
+  
     refreshData = () => this.router.refresh();
   }
   ```

--- a/ember-resources/CHANGELOG.md
+++ b/ember-resources/CHANGELOG.md
@@ -45,8 +45,9 @@
     @service declare router: RouterService;
 
     poll = helper(function ([fn, interval]: [(...args: unknown[]) => unknown, number]) {
-      if (!intervals.has(this))
+      if (!intervals.has(this)) {
         registerDestructor(this, () => clearInterval(intervals.get(this)));
+      }
       clearInterval(intervals.get(this);
       intervals.set(this, setInterval(fn, interval));
     });


### PR DESCRIPTION
The example in the original had some bugs. As it initiated a new `setInterval` on every compute it just keep adding every time Ember recomputed the helper. It also would register a destructor on every compute.

This change uses a WeakMap to track the intervals and only registers a destructor once.