### PR TITLE
Push the built contents of the npm package to a branch on every commit to main

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
         with:
           branch: dist
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ember-resources

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,20 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.PAT }}
+          working-directory: ember-resources

--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -87,7 +87,8 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "test": "echo 'Addon does not have tests, run tests in test-app'",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "pnpm run build",
+    "prepack": "pnpm run build"
   },
   "dependencies": {
     "@babel/runtime": "^7.17.8",


### PR DESCRIPTION
This uses an action I created: https://github.com/kategengler/put-built-npm-package-contents-on-branch

I added a `prepack` script in the ember-resources dir so that the defaults of the action would just work, otherwise it could be done before the action in the workflow. 

This requires a `token` to be passed that has write access to the contents of the repo (either `secrets.GITHUB_TOKEN` if you enable that token having write access or a correctly set up personal access token).

The action has several inputs for customization https://github.com/kategengler/put-built-npm-package-contents-on-branch#inputs