### PR TITLE
Add aliases to trackedFunction

### DIFF
--- a/.changeset/hungry-waves-kiss.md
+++ b/.changeset/hungry-waves-kiss.md
@@ -24,10 +24,24 @@ and abstract away the various states involved with async behavior. Now that the 
 
 **Migration**
 
-**_Previously_**, the state's `isResolved` property on `trackedFunction` was `true` on both success and error.
+**_Previously_, the state's `isResolved` property on `trackedFunction` was `true` on both success and error.**
 
 _now_, `isFinished` can be used instead. 
 `isResolved` is now only true when the function runs to completion without error, aligning with the semantics of promises.
+
+```js
+class Demo {
+  foo = trackedFunction(this, async () => {
+    /* ... */
+  });
+
+  <template>
+    {{this.foo.isFinished}} =
+      {{this.foo.isResolved}} or
+      {{this.foo.isError}}
+  </template>
+}
+```
 
 
 **_Previously_, `trackedFunction` could take an initial value for its second argument.**
@@ -79,21 +93,3 @@ class Demo extends Component {
 }
 ```
 
-**_Previously_, the `isResolved` property was `true` for succesful and error states**
-
-Now, `isResolved` is only true when the function passed to `trackedFunction` has succesfully
-completed.
-
-To have behavior similar to the old behavior, you may want to implement your own `isFinished` getter:
-
-```js
-class Demo {
-  foo = trackedFunction(this, async () => {
-    /* ... */
-  });
-
-  get isFinished() {
-    return this.foo.isResolved || this.foo.isRejected;
-  }
-}
-```

--- a/.changeset/hungry-waves-kiss.md
+++ b/.changeset/hungry-waves-kiss.md
@@ -10,8 +10,6 @@ tl;dr: the breaking changes:
 
 - no more manual initial value
 - `isResolved` is only true on success
-- `isError` has been renamed to `isRejected`
-- `isLoading` has been removed as it was redundant
 
 other changes:
 

--- a/.changeset/hungry-waves-kiss.md
+++ b/.changeset/hungry-waves-kiss.md
@@ -24,6 +24,12 @@ and abstract away the various states involved with async behavior. Now that the 
 
 **Migration**
 
+**_Previously_**, the state's `isResolved` property on `trackedFunction` was `true` on both success and error.
+
+_now_, `isFinished` can be used instead. 
+`isResolved` is now only true when the function runs to completion without error, aligning with the semantics of promises.
+
+
 **_Previously_, `trackedFunction` could take an initial value for its second argument.**
 
 ```js

--- a/ember-resources/src/util/function.ts
+++ b/ember-resources/src/util/function.ts
@@ -79,16 +79,55 @@ export class State<Value> {
     return this.data?.state ?? 'UNSTARTED';
   }
 
+  /**
+   * Initially true, and remains true
+   * until the underlying promise resolves or rejects.
+   */
   get isPending() {
     if (!this.data) return true;
 
     return this.data.isPending ?? false;
   }
 
+  /**
+   * Alias for `isResolved || isRejected`
+   */
+  get isFinished() {
+    return this.isResolved || this.isRejected;
+  }
+
+  /**
+   * Alias for `isFinished`
+   * which is in turn an alias for `isResolved || isRejected`
+   */
+  get isSettled() {
+    return this.isFinished;
+  }
+
+  /**
+   * Alias for `isPending`
+   */
+  get isLoading() {
+    return this.isPending;
+  }
+
+  /**
+   * When true, the function passed to `trackedFunction` has resolved
+   */
   get isResolved() {
     return this.data?.isResolved ?? false;
   }
 
+  /**
+   * Alias for `isRejected`
+   */
+  get isError() {
+    return this.isRejected;
+  }
+
+  /**
+   * When true, the function passed to `trackedFunction` has errored
+   */
   get isRejected() {
     return this.data?.isRejected ?? false;
   }
@@ -116,6 +155,10 @@ export class State<Value> {
     return null;
   }
 
+  /**
+   * When the function passed to `trackedFunction` throws an error,
+   * that error will be the value returned by this property
+   */
   get error() {
     return this.data?.error ?? null;
   }


### PR DESCRIPTION
A couple have provided feedback, and for DX, folks agree that having more aliases for representing promise state is preferred