### PR TITLE
fix: `trackedTask` must return correct last value

### DIFF
--- a/.changeset/many-brooms-turn.md
+++ b/.changeset/many-brooms-turn.md
@@ -1,0 +1,9 @@
+---
+"ember-resources": patch
+---
+
+`trackedTask` must return correct last value.
+
+Fixes the issue described at #793
+If the task was called multiple times and the last returned value was null or undefined,
+then trackedTask will return the previous value instead of the current one.

--- a/ember-resources/src/util/ember-concurrency.ts
+++ b/ember-resources/src/util/ember-concurrency.ts
@@ -214,7 +214,11 @@ export class TaskResource<
   declare lastTask: TaskInstance<Return> | undefined;
 
   get value() {
-    return this.currentTask.value ?? this.lastTask?.value;
+    if (this.currentTask?.isFinished) {
+      return this.currentTask.value;
+    }
+
+    return this.lastTask?.value;
   }
 
   modify(positional: Args) {

--- a/test-app/tests/utils/ember-concurrency/js-test.ts
+++ b/test-app/tests/utils/ember-concurrency/js-test.ts
@@ -107,6 +107,67 @@ module('useTask', function () {
         assert.false(foo.search.isRunning);
         assert.deepEqual(foo.search.value, { results: ['Hello there!'] });
       });
+
+      test('it returns correct task value if "task" function returned "undefined" or "null"', async function (assert) {
+        class Test {
+          @tracked input: string | undefined | null = 'initial value';
+
+          search = trackedTask(this, taskFor(this._search), () => [this.input]);
+
+          @restartableTask
+          *_search(input: string | undefined | null) {
+            // or some bigger timeout for an actual search task to debounce
+            yield timeout(0);
+
+            // or some api data if actual search task
+            return input;
+          }
+        }
+
+        let foo = new Test();
+
+        // task is initiated upon first access
+        foo.search;
+        await settled();
+
+        assert.strictEqual(foo.search.value, undefined);
+        assert.false(foo.search.isFinished);
+        assert.true(foo.search.isRunning);
+
+        await settled();
+
+        assert.true(foo.search.isFinished);
+        assert.false(foo.search.isRunning);
+        assert.strictEqual(foo.search.value, 'initial value');
+
+        // "trackedTask" must return "undefined" as current (latest) value
+        foo.input = undefined;
+        await settled();
+
+        assert.strictEqual(foo.search.value, 'initial value', 'previous value is retained');
+        assert.false(foo.search.isFinished);
+        assert.true(foo.search.isRunning);
+
+        await settled();
+
+        assert.true(foo.search.isFinished);
+        assert.false(foo.search.isRunning);
+        assert.strictEqual(foo.search.value, undefined);
+
+        // "trackedTask" must return "null" as current (latest) value
+        foo.input = null;
+        await settled();
+
+        assert.strictEqual(foo.search.value, undefined, 'previous value is retained');
+        assert.false(foo.search.isFinished);
+        assert.true(foo.search.isRunning);
+
+        await settled();
+
+        assert.true(foo.search.isFinished);
+        assert.false(foo.search.isRunning);
+        assert.strictEqual(foo.search.value, null);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR fixes the issue described at https://github.com/NullVoxPopuli/ember-resources/issues/793

The issue: If the task was called multiple times and the last returned value was `null` or `undefined`, then `trackedTask` will return the previous value instead of the current one.

