### PR TITLE
exit beta

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "docs": "0.0.0",


### PR DESCRIPTION
This PR tells the changeset automation to queue up a release for v6.0.0, and stop releasing v6.0.0-betas.
This closes #783