### PR TITLE
Debounce: make it possible to inmediately return the initial value

### DIFF
--- a/test-app/tests/utils/debounce/js-test.ts
+++ b/test-app/tests/utils/debounce/js-test.ts
@@ -14,7 +14,7 @@ module('Utils | debounce | js', function (hooks) {
   module('debounce', function () {
     test('works with @use', async function (assert) {
       class Test {
-        @tracked data = '';
+        @tracked data = 'initial';
 
         @use text = debounce(100, () => this.data);
       }
@@ -23,24 +23,75 @@ module('Utils | debounce | js', function (hooks) {
 
       setOwner(test, this.owner);
 
-      assert.strictEqual(test.text, undefined);
+      assert.strictEqual(test.text, undefined, 'Initial value is undefined');
 
       test.data = 'b';
-      await someTime();
-      assert.strictEqual(test.text, undefined);
-      test.data = 'bo';
-      await someTime();
-      assert.strictEqual(test.text, undefined);
-      test.data = 'boo';
-      await someTime();
-      assert.strictEqual(test.text, undefined);
 
+      // 25ms
+      await someTime();
+      assert.strictEqual(test.text, undefined, 'Initial value is undefined');
+      test.data = 'bo';
+
+      // another 25ms (= ~50ms < 100ms debounce)
+      await someTime();
+      assert.strictEqual(test.text, undefined, 'Initial value is undefined');
+      test.data = 'boo';
+
+      // another 25ms (= ~75ms < 100ms debounce)
+      await someTime();
+      assert.strictEqual(test.text, undefined, 'Initial value is undefined');
+
+      // 110ms > 100ms debounce, value should be set now
       await someTime(110);
       assert.strictEqual(test.text, 'boo');
 
+      // change the value again, wait 0ms, value is not updated yet
       test.data = 'boop';
       assert.strictEqual(test.text, 'boo');
 
+      // wait at least 100ms, value is now updated
+      await someTime(110);
+      assert.strictEqual(test.text, 'boop');
+    });
+
+    test('initialize = true', async function (assert) {
+      class Test {
+        @tracked data = 'initial';
+
+        @use text = debounce(100, () => this.data, true);
+      }
+
+      let test = new Test();
+
+      setOwner(test, this.owner);
+
+      assert.strictEqual(test.text, 'initial');
+
+      test.data = 'b';
+
+      // 25ms
+      await someTime();
+      assert.strictEqual(test.text, 'initial');
+      test.data = 'bo';
+
+      // another 25ms (= ~50ms < 100ms debounce)
+      await someTime();
+      assert.strictEqual(test.text, 'initial');
+      test.data = 'boo';
+
+      // another 25ms (= ~75ms < 100ms debounce)
+      await someTime();
+      assert.strictEqual(test.text, 'initial');
+
+      // 110ms > 100ms debounce, value should be set now
+      await someTime(110);
+      assert.strictEqual(test.text, 'boo');
+
+      // change the value again, wait 0ms, value is not updated yet
+      test.data = 'boop';
+      assert.strictEqual(test.text, 'boo');
+
+      // wait at least 100ms, value is now updated
       await someTime(110);
       assert.strictEqual(test.text, 'boop');
     });


### PR DESCRIPTION
Use case:
- You have a computed property, for instance a query, which gets updated by some filters in your UI.
- The initial debouncedQuery should be set to the value of query, and updates after that should be debounced by x ms