### PR TITLE
Omit thunk in class-based resources when not needed

### DIFF
--- a/ember-resources/src/core/class-based/resource.ts
+++ b/ember-resources/src/core/class-based/resource.ts
@@ -175,6 +175,27 @@ export class Resource<Args = unknown> {
   declare [Invoke]: ResourceHelperLike<Args, this>[typeof Invoke];
 
   /**
+   * For use in the body of a class, without reactive arguments.
+   *
+   * `from` is what allows resources to be used in JS, they hide the reactivity APIs
+   * from the consumer so that the surface API is smaller.
+   *
+   * ```js
+   * import { Resource } from 'ember-resources';
+   *
+   * class SomeResource extends Resource {}
+   *
+   * class MyClass {
+   *   data = SomeResource.from(this);
+   * }
+   * ```
+   */
+  static from<SomeResource extends Resource<any>>(
+    this: Constructor<SomeResource>,
+    context: unknown
+  ): SomeResource;
+
+  /**
    * For use in the body of a class.
    *
    * `from` is what allows resources to be used in JS, they hide the reactivity APIs

--- a/test-app/tests/core/class-resource/js-test.ts
+++ b/test-app/tests/core/class-resource/js-test.ts
@@ -141,6 +141,7 @@ module('Core | (class) Resource | js', function (hooks) {
     }
 
     class Test {
+      data = TestResource.from(this);
       dataArray = TestResource.from(this, () => []);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       dataVoid = TestResource.from(this, () => {});
@@ -150,6 +151,7 @@ module('Core | (class) Resource | js', function (hooks) {
 
     let foo = new Test();
 
+    assert.strictEqual(foo.data.foo, 3);
     assert.strictEqual(foo.dataArray.foo, 3);
     assert.strictEqual(foo.dataVoid.foo, 3);
     assert.strictEqual(foo.dataOmitted.foo, 3);


### PR DESCRIPTION
When using a `Resource` but not using arguments with reactive parameters, then initializing them, so far still required the usage of a thunk, ie:

```ts
class TestResource extends Resource {
  foo = 3;
}

class Test {
  data = TestResource.from(this, () => []);
}
```

... for basically, no reason. This PR makes thunks a non-required parameter, leading into cleaner code like so:

```ts
class TestResource extends Resource {
  foo = 3;
}

class Test {
  data = TestResource.from(this);
}
```

:) 