### PR TITLE
Fix issue with keepLatest and empty values

### DIFF
--- a/ember-resources/src/util/keep-latest.ts
+++ b/ember-resources/src/util/keep-latest.ts
@@ -70,12 +70,31 @@ interface Options<T = unknown> {
 export function keepLatest<Return = unknown>({ when, value: valueFn }: Options<Return>) {
   return resource(() => {
     let previous: Return;
+    let initial = true;
 
     return () => {
       let value = valueFn();
 
+
       if (when()) {
-        return (previous = isEmpty(value) && !isEmpty(previous) ? previous : value);
+        /**
+          * Initially, if we may as well return the value instead
+          * of the "previous" value is there is no previous yet.
+          *
+          * We check against undefined, because that's what
+          * `previous` is "initialized" to.
+          *
+          * And then we never enter this block again, because
+          * we will have previous values in future invocations of this
+          * Formula.
+          */
+        if (previous === undefined && initial) {
+          initial = false;
+
+          return value;
+        }
+
+        return (previous = isEmpty(value) ? previous : value);
       }
 
       return (previous = value);

--- a/ember-resources/src/util/keep-latest.ts
+++ b/ember-resources/src/util/keep-latest.ts
@@ -75,7 +75,7 @@ export function keepLatest<Return = unknown>({ when, value: valueFn }: Options<R
       let value = valueFn();
 
       if (when()) {
-        return (previous = isEmpty(value) ? previous : value);
+        return (previous = isEmpty(value) && !isEmpty(previous) ? previous : value);
       }
 
       return (previous = value);

--- a/ember-resources/src/util/keep-latest.ts
+++ b/ember-resources/src/util/keep-latest.ts
@@ -75,19 +75,18 @@ export function keepLatest<Return = unknown>({ when, value: valueFn }: Options<R
     return () => {
       let value = valueFn();
 
-
       if (when()) {
         /**
-          * Initially, if we may as well return the value instead
-          * of the "previous" value is there is no previous yet.
-          *
-          * We check against undefined, because that's what
-          * `previous` is "initialized" to.
-          *
-          * And then we never enter this block again, because
-          * we will have previous values in future invocations of this
-          * Formula.
-          */
+         * Initially, if we may as well return the value instead
+         * of the "previous" value is there is no previous yet.
+         *
+         * We check against undefined, because that's what
+         * `previous` is "initialized" to.
+         *
+         * And then we never enter this block again, because
+         * we will have previous values in future invocations of this
+         * Formula.
+         */
         if (previous === undefined && initial) {
           initial = false;
 

--- a/test-app/tests/utils/keep-latest/js-test.ts
+++ b/test-app/tests/utils/keep-latest/js-test.ts
@@ -32,7 +32,7 @@ module('Utils | keepLatest | js', function (hooks) {
 
     let instance = new Test();
 
-    assert.strictEqual(instance.data, undefined);
+    assert.strictEqual(instance.data, null);
 
     await timeout(100);
 

--- a/test-app/tests/utils/keep-latest/rendering-test.gts
+++ b/test-app/tests/utils/keep-latest/rendering-test.gts
@@ -1,10 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 // @ts-ignore @ember/helper does not provide types :(
 import { fn, hash } from '@ember/helper';
-// @ts-ignore there is no @types/* package for this
-// import { renderSettled } from '@ember/renderer';
-// @ts-ignore @ember/renderer doesn't exist in old Ember
-export { renderSettled } from '@ember/-internals/glimmer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -92,20 +88,20 @@ module('Utils | keepLatest | rendering', function (hooks) {
     assert.dom().hasText('[1]');
 
     instance.x = [];
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[1]');
     await settled();
     assert.dom().hasText('[]');
 
     instance.x = 0;
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[]');
 
     await settled();
     assert.dom().hasText('0');
 
     instance.x = [1];
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('0');
 
     await settled();
@@ -113,7 +109,7 @@ module('Utils | keepLatest | rendering', function (hooks) {
 
     instance.x = [1, 2];
     assert.dom().hasText('[1]');
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[1]');
 
     await settled();
@@ -147,7 +143,7 @@ module('Utils | keepLatest | rendering', function (hooks) {
 
     render(<template>{{JSON.stringify instance.data}}</template>);
 
-    await renderSettled();
+    await timeout(8);
     /**
       * Initially, a `trackedFunction` returns null.
       * we could craft a resource that returns something other than null,
@@ -162,20 +158,20 @@ module('Utils | keepLatest | rendering', function (hooks) {
     assert.dom().hasText('[1]', 'non-empty value exists and set explicitly');
 
     instance.x = [];
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[1]', 'retains previous value of [1]');
     await settled();
     assert.dom().hasText('[]', 'value resolved to empty []');
 
     instance.x = null;
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[]', 'retains previous value of []');
 
     await settled();
     assert.dom().hasText('"default"', 'empty value set, falling back to default');
 
     instance.x = [1];
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('"default"', 'not yet resolved, previous value used');
 
     await settled();
@@ -183,7 +179,7 @@ module('Utils | keepLatest | rendering', function (hooks) {
 
     instance.x = [1, 2];
     assert.dom().hasText('[1]', 'retains previous non-empty value');
-    await renderSettled();
+    await timeout(8);
     assert.dom().hasText('[1]', 'retains previous non-empty value');
 
     await settled();

--- a/test-app/tests/utils/keep-latest/rendering-test.gts
+++ b/test-app/tests/utils/keep-latest/rendering-test.gts
@@ -2,7 +2,9 @@ import { tracked } from '@glimmer/tracking';
 // @ts-ignore @ember/helper does not provide types :(
 import { fn, hash } from '@ember/helper';
 // @ts-ignore there is no @types/* package for this
-import { renderSettled } from '@ember/renderer';
+// import { renderSettled } from '@ember/renderer';
+// @ts-ignore @ember/renderer doesn't exist in old Ember
+export { renderSettled } from '@ember/-internals/glimmer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';

--- a/test-app/tests/utils/keep-latest/rendering-test.gts
+++ b/test-app/tests/utils/keep-latest/rendering-test.gts
@@ -1,9 +1,9 @@
 import { tracked } from '@glimmer/tracking';
 // @ts-ignore @ember/helper does not provide types :(
 import { fn, hash } from '@ember/helper';
+import { renderSettled } from '@ember/renderer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { renderSettled } from '@ember/renderer';
 import { setupRenderingTest } from 'ember-qunit';
 
 import { use } from 'ember-resources';

--- a/test-app/tests/utils/keep-latest/rendering-test.gts
+++ b/test-app/tests/utils/keep-latest/rendering-test.gts
@@ -3,8 +3,10 @@ import { tracked } from '@glimmer/tracking';
 import { fn, hash } from '@ember/helper';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
+import { renderSettled } from '@ember/renderer';
 import { setupRenderingTest } from 'ember-qunit';
 
+import { use } from 'ember-resources';
 import { trackedFunction } from 'ember-resources/util/function';
 import { keepLatest } from 'ember-resources/util/keep-latest';
 
@@ -55,5 +57,133 @@ module('Utils | keepLatest | rendering', function (hooks) {
     assert.dom().hasText('1');
     await timeout(40);
     assert.dom().hasText('2');
+  });
+
+  test('if the previous value is not empty, and the current value is empty', async function (assert) {
+    class Test {
+      @tracked x: number[] | number = [];
+
+      // @use request = trackedFunction(async () => {
+      request = trackedFunction(this, async () => {
+        let value = this.x;
+
+        await timeout(10);
+
+        return value;
+      });
+
+      @use data = keepLatest({
+        when: () => this.request.isPending,
+        value: () => this.request.value,
+      })
+    }
+
+    let instance = new Test();
+
+    await render(<template>{{JSON.stringify instance.data}}</template>);
+
+    assert.dom().hasText('[]');
+
+    instance.x = [1];
+    await settled();
+    assert.dom().hasText('[1]');
+
+    instance.x = [];
+    await renderSettled();
+    assert.dom().hasText('[1]');
+    await settled();
+    assert.dom().hasText('[]');
+
+    instance.x = 0;
+    await renderSettled();
+    assert.dom().hasText('[]');
+
+    await settled();
+    assert.dom().hasText('0');
+
+    instance.x = [1];
+    await renderSettled();
+    assert.dom().hasText('0');
+
+    await settled();
+    assert.dom().hasText('[1]');
+
+    instance.x = [1, 2];
+    assert.dom().hasText('[1]');
+    await renderSettled();
+    assert.dom().hasText('[1]');
+
+    await settled();
+    assert.dom().hasText('[1,2]');
+  });
+
+  test('with a default value, if the previous value is not empty, and the current value is empty', async function (assert) {
+    class Test {
+      @tracked x: number[] | null | number = [];
+
+      // @use request = trackedFunction(async () => {
+      request = trackedFunction(this, async () => {
+        let value = this.x;
+
+        await timeout(10);
+
+        return value;
+      });
+
+      @use latest = keepLatest({
+        when: () => this.request.isPending,
+        value: () => this.request.value,
+      })
+
+      get data() {
+        return this.latest ?? 'default';
+      }
+    }
+
+    let instance = new Test();
+
+    render(<template>{{JSON.stringify instance.data}}</template>);
+
+    await renderSettled();
+    /**
+      * Initially, a `trackedFunction` returns null.
+      * we could craft a resource that returns something other than null,
+      * initially, but null ?? 'default' is 'default'.
+      */
+    assert.dom().hasText('"default"', 'pre-settled, value exists ');
+    await settled();
+    assert.dom().hasText('[]', 'value exists, and set explicitly');
+
+    instance.x = [1];
+    await settled();
+    assert.dom().hasText('[1]', 'non-empty value exists and set explicitly');
+
+    instance.x = [];
+    await renderSettled();
+    assert.dom().hasText('[1]', 'retains previous value of [1]');
+    await settled();
+    assert.dom().hasText('[]', 'value resolved to empty []');
+
+    instance.x = null;
+    await renderSettled();
+    assert.dom().hasText('[]', 'retains previous value of []');
+
+    await settled();
+    assert.dom().hasText('"default"', 'empty value set, falling back to default');
+
+    instance.x = [1];
+    await renderSettled();
+    assert.dom().hasText('"default"', 'not yet resolved, previous value used');
+
+    await settled();
+    assert.dom().hasText('[1]', 'value resolved to [1]');
+
+    instance.x = [1, 2];
+    assert.dom().hasText('[1]', 'retains previous non-empty value');
+    await renderSettled();
+    assert.dom().hasText('[1]', 'retains previous non-empty value');
+
+    await settled();
+    assert.dom().hasText('[1,2]', 'new value is resolved');
   });
 });

--- a/test-app/tests/utils/keep-latest/rendering-test.gts
+++ b/test-app/tests/utils/keep-latest/rendering-test.gts
@@ -1,6 +1,7 @@
 import { tracked } from '@glimmer/tracking';
 // @ts-ignore @ember/helper does not provide types :(
 import { fn, hash } from '@ember/helper';
+// @ts-ignore there is no @types/* package for this
 import { renderSettled } from '@ember/renderer';
 import { render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';


### PR DESCRIPTION
tl;dr:

- use the `value` on the first run of the `keepLatest`, if available (instead of previous, which is always `undefined`)
- add tests clarifying behavior

-----------

The way to provide a default value when the value of keepLatest is false is to use another getter.

This PR adds a couple tests clarifying that behavior:

```ts
class Demo {
  @use latest = keepLatest({
    value: () => this.data.value?.meta,
    when: () => this.data.isLoading,    
  })

  get theData() {
    return this.latest ?? 'default value';
  }
}
```

It's important to not do
```js
   value: () => this.data.value?.meta ?? {},
```

because that means falsey responses (on `data`), will resolve to `{}`, and cause content flashes.

So to keep the latest value, you want to let the `data` response be what it actually is.

In traditional logic, this could maybe be expressed this way:

```
value ?? default ?? previous
```
when default is always truthy
vs
```
(value ?? previous) ?? default
```