### PR TITLE
Require an owner to exist to be wired through to the resource.

### DIFF
--- a/ember-resources/src/function-based/immediate-invocation.ts
+++ b/ember-resources/src/function-based/immediate-invocation.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { assert } from '@ember/debug';
 import { associateDestroyableChild } from '@ember/destroyable';
 // @ts-ignore
 import { capabilities as helperCapabilities, invokeHelper, setHelperManager } from '@ember/helper';
@@ -37,7 +38,7 @@ class ResourceInvokerManager {
     hasDestroyable: true,
   });
 
-  constructor(protected owner: Owner) {}
+  constructor(protected owner: Owner) { }
 
   createHelper(fn: ResourceFactory, args: any): State {
     /**
@@ -178,4 +179,8 @@ type ResourceBlueprint<Value, Args> =
 // semicolon
 
 // Provide a singleton manager.
-const ResourceInvokerFactory = (owner: Owner) => new ResourceInvokerManager(owner);
+const ResourceInvokerFactory = (owner: Owner | undefined) => {
+  assert(`Cannot create resource without an owner`, owner);
+
+  return new ResourceInvokerManager(owner);
+};

--- a/ember-resources/src/function-based/immediate-invocation.ts
+++ b/ember-resources/src/function-based/immediate-invocation.ts
@@ -38,7 +38,7 @@ class ResourceInvokerManager {
     hasDestroyable: true,
   });
 
-  constructor(protected owner: Owner) { }
+  constructor(protected owner: Owner) {}
 
   createHelper(fn: ResourceFactory, args: any): State {
     /**

--- a/ember-resources/src/function-based/manager.ts
+++ b/ember-resources/src/function-based/manager.ts
@@ -46,7 +46,7 @@ class FunctionResourceManager {
     hasDestroyable: true,
   });
 
-  constructor(protected owner: Owner) {}
+  constructor(protected owner: Owner) { }
 
   /**
    * Resources do not take args.
@@ -150,4 +150,8 @@ function isReactive<Value>(maybe: unknown): maybe is Reactive<Value> {
   return typeof maybe === 'object' && maybe !== null && CURRENT in maybe;
 }
 
-export const ResourceManagerFactory = (owner: Owner) => new FunctionResourceManager(owner);
+export const ResourceManagerFactory = (owner: Owner | undefined) => {
+  assert(`Cannot create resource without an owner`, owner);
+
+  return new FunctionResourceManager(owner);
+};

--- a/ember-resources/src/function-based/manager.ts
+++ b/ember-resources/src/function-based/manager.ts
@@ -46,7 +46,7 @@ class FunctionResourceManager {
     hasDestroyable: true,
   });
 
-  constructor(protected owner: Owner) { }
+  constructor(protected owner: Owner) {}
 
   /**
    * Resources do not take args.

--- a/test-app/tests/core/function-resource/clock-test.gts
+++ b/test-app/tests/core/function-resource/clock-test.gts
@@ -2,6 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { destroy } from '@ember/destroyable';
 // @ts-ignore @ember/helper does not provide types :(
 import { hash } from '@ember/helper';
+import { setOwner } from '@ember/owner';
 import { clearRender, find, render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest, setupTest } from 'ember-qunit';
@@ -57,6 +58,8 @@ module('Examples | resource | Clock', function (hooks) {
       }
 
       let foo = new Test();
+
+      setOwner(foo, this.owner);
 
       let timeA = foo.now;
 

--- a/test-app/tests/core/function-resource/clock-test.gts
+++ b/test-app/tests/core/function-resource/clock-test.gts
@@ -2,12 +2,26 @@ import { tracked } from '@glimmer/tracking';
 import { destroy } from '@ember/destroyable';
 // @ts-ignore @ember/helper does not provide types :(
 import { hash } from '@ember/helper';
-import { setOwner } from '@ember/owner';
 import { clearRender, find, render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest, setupTest } from 'ember-qunit';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import { cell, resource, resourceFactory, use } from 'ember-resources';
+
+import type Owner from '@ember/owner';
+
+let setOwner: (context: unknown, owner: Owner) => void;
+
+if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
+  // In no version of ember where `@ember/owner` tried to be imported did it exist
+  // if (macroCondition(false)) {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/owner') as any).setOwner;
+} else {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/application') as any).setOwner;
+}
 
 module('Examples | resource | Clock', function (hooks) {
   let wait = (ms = 1_100) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/test-app/tests/core/function-resource/js-test.ts
+++ b/test-app/tests/core/function-resource/js-test.ts
@@ -31,6 +31,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
     let foo = new Test();
 
+    setOwner(foo, this.owner);
+
     assert.strictEqual(foo.data, 0);
     await settled();
 
@@ -66,6 +68,8 @@ module('Utils | (function) resource | js', function (hooks) {
     test('basics', async function (assert) {
       let foo = new Test(assert);
 
+      setOwner(foo, this.owner);
+
       assert.strictEqual(foo.data, 1);
 
       destroy(foo);
@@ -76,6 +80,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
     test('reactivity', async function (assert) {
       let foo = new Test(assert);
+
+      setOwner(foo, this.owner);
 
       assert.strictEqual(foo.data, 1);
 
@@ -109,6 +115,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
     test('async reactivity', async function (assert) {
       let foo = new Test(assert);
+
+      setOwner(foo, this.owner);
 
       assert.strictEqual(foo.data, 1);
 
@@ -174,6 +182,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
       let foo = new Test(assert);
 
+      setOwner(foo, this.owner);
+
       assert.strictEqual(foo.data, 1);
 
       foo.count = 2;
@@ -235,6 +245,8 @@ module('Utils | (function) resource | js', function (hooks) {
     test('basics', async function (assert) {
       let foo = new Test(assert);
 
+      setOwner(foo, this.owner);
+
       assert.strictEqual(foo.data, 1);
 
       destroy(foo);
@@ -245,6 +257,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
     test('reactivity', async function (assert) {
       let foo = new Test(assert);
+
+      setOwner(foo, this.owner);
 
       assert.strictEqual(foo.data, 1);
 
@@ -264,6 +278,8 @@ module('Utils | (function) resource | js', function (hooks) {
 
     test('async reactivity', async function (assert) {
       let foo = new Test(assert);
+
+      setOwner(foo, this.owner);
 
       assert.strictEqual(foo.data, 1);
 
@@ -307,6 +323,8 @@ module('Utils | (function) resource | js', function (hooks) {
       const testService = this.owner.lookup('service:test') as TestService;
 
       let test = new Test();
+
+      setOwner(test, this.owner);
 
       setOwner(test, this.owner);
 

--- a/test-app/tests/core/function-resource/js-test.ts
+++ b/test-app/tests/core/function-resource/js-test.ts
@@ -1,14 +1,27 @@
 import { tracked } from '@glimmer/tracking';
-import { setOwner } from '@ember/application';
 import { destroy } from '@ember/destroyable';
 import Service from '@ember/service';
 import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import { cell, resource, use } from 'ember-resources';
 
+import type Owner from '@ember/owner';
 import type QUnit from 'qunit';
+
+let setOwner: (context: unknown, owner: Owner) => void;
+
+if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
+  // In no version of ember where `@ember/owner` tried to be imported did it exist
+  // if (macroCondition(false)) {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/owner') as any).setOwner;
+} else {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/application') as any).setOwner;
+}
 
 module('Utils | (function) resource | js', function (hooks) {
   setupTest(hooks);

--- a/test-app/tests/core/function-resource/js-use-test.gts
+++ b/test-app/tests/core/function-resource/js-use-test.gts
@@ -1,14 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { tracked } from '@glimmer/tracking';
 import { destroy, isDestroyed, registerDestructor } from '@ember/destroyable';
-import { setOwner } from '@ember/owner';
 import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import { resource, resourceFactory, use } from 'ember-resources';
 
 import type Owner from '@ember/owner';
+
+let setOwner: (context: unknown, owner: Owner) => void;
+
+if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
+  // In no version of ember where `@ember/owner` tried to be imported did it exist
+  // if (macroCondition(false)) {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/owner') as any).setOwner;
+} else {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/application') as any).setOwner;
+}
 
 // not testing in template, because that's the easy part
 module('Core | (function) resource + use | js', function (hooks) {

--- a/test-app/tests/core/function-resource/js-use-test.gts
+++ b/test-app/tests/core/function-resource/js-use-test.gts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { tracked } from '@glimmer/tracking';
 import { destroy, isDestroyed, registerDestructor } from '@ember/destroyable';
+import { setOwner } from '@ember/owner';
 import { settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -33,6 +34,8 @@ module('Core | (function) resource + use | js', function (hooks) {
 
     let foo = new Test();
 
+    setOwner(foo, this.owner);
+
     assert.strictEqual(foo.data, 4);
   });
 
@@ -55,6 +58,8 @@ module('Core | (function) resource + use | js', function (hooks) {
     }
 
     let foo = new Test();
+
+    setOwner(foo, this.owner);
 
     assert.strictEqual(foo.data.current, 0);
 
@@ -85,6 +90,8 @@ module('Core | (function) resource + use | js', function (hooks) {
     }
 
     let foo = new Test();
+
+    setOwner(foo, this.owner);
 
     // destruction only occurs if the resource is constructor, which would be upon access
     foo.data.current;
@@ -126,6 +133,8 @@ module('Core | (function) resource + use | js', function (hooks) {
 
     let foo = new Test();
 
+    setOwner(foo, this.owner);
+
     foo.data.current;
     foo.count = 4;
     foo.data.current;
@@ -152,6 +161,8 @@ module('Core | (function) resource + use | js', function (hooks) {
     }
 
     let foo = new Test();
+
+    setOwner(foo, this.owner);
 
     assert.strictEqual(foo.data1, 'hello');
     assert.strictEqual(foo.data2.current, 'hello');

--- a/test-app/tests/core/function-resource/rendering-test.gts
+++ b/test-app/tests/core/function-resource/rendering-test.gts
@@ -1,12 +1,26 @@
 import { tracked } from '@glimmer/tracking';
-import { setOwner } from '@ember/application';
 import { destroy } from '@ember/destroyable';
 import Service from '@ember/service';
 import { clearRender, render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import { cell,resource, use } from 'ember-resources';
+
+import type Owner from '@ember/owner';
+
+let setOwner: (context: unknown, owner: Owner) => void;
+
+if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
+  // In no version of ember where `@ember/owner` tried to be imported did it exist
+  // if (macroCondition(false)) {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/owner') as any).setOwner;
+} else {
+  // Using 'any' here because importSync can't lookup types correctly
+  setOwner = (importSync('@ember/application') as any).setOwner;
+}
 
 module('Utils | (function) resource | rendering', function (hooks) {
   setupRenderingTest(hooks);

--- a/test-app/tests/core/function-resource/rendering-test.gts
+++ b/test-app/tests/core/function-resource/rendering-test.gts
@@ -27,6 +27,9 @@ module('Utils | (function) resource | rendering', function (hooks) {
         }
 
         let foo = new Test();
+
+    setOwner(foo, this.owner);
+
         // reminder that destruction is async
         let steps: string[] = [];
         let step = (msg: string) => {
@@ -71,6 +74,9 @@ module('Utils | (function) resource | rendering', function (hooks) {
         }
 
         let foo = new Test();
+
+    setOwner(foo, this.owner);
+
         // reminder that destruction is async
         let steps: string[] = [];
         let step = (msg: string) => {
@@ -120,6 +126,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
         let inc = 0;
         let foo = new Test();
 
+    setOwner(foo, this.owner);
+
         let theResource = resource(({ on }) => {
           let i = inc;
 
@@ -166,6 +174,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
 
         let foo = new Test();
 
+    setOwner(foo, this.owner);
+
         let theResource = resource(({ on }) => {
           let i = foo.num;
 
@@ -211,6 +221,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
         }
 
         let foo = new Test();
+
+    setOwner(foo, this.owner);
 
         let theResource = (_num: number) =>
           resource(({ on }) => {
@@ -278,6 +290,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
 
         let foo = new Test();
 
+    setOwner(foo, this.owner);
+
         await render(<template><out>{{foo.theResource}}</out></template>);
 
         assert.dom('out').containsText('0');
@@ -320,6 +334,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
         }
 
         let foo = new Test();
+
+    setOwner(foo, this.owner);
 
         await render(<template>
           {{#if foo.show}}
@@ -377,6 +393,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
 
         let foo = new Test();
 
+    setOwner(foo, this.owner);
+
         await render(<template>
           {{#if foo.show}}
             <out>{{foo.theResource}}</out>
@@ -425,6 +443,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
       }
 
       let foo = new Test();
+
+    setOwner(foo, this.owner);
 
       await render(<template>
         {{#let (Wrapper foo.num) as |state|}}
@@ -482,6 +502,8 @@ module('Utils | (function) resource | rendering', function (hooks) {
       const testService = this.owner.lookup('service:test') as TestService;
 
       let testData = new Test();
+
+    setOwner(testData, this.owner);
 
       setOwner(testData, this.owner);
 


### PR DESCRIPTION
Without this it's possible to break the public API of `resource`

for example:

```js
const Clock = resource(({ owner }) => {
  owner.lookup(...)
});
```
would fail if the resource is constructed in a vanilla class that doesn't have an owner.

This _likely_ will only affect tests.