### PR TITLE
Fix use types

### DIFF
--- a/ember-resources/src/function-based/types.ts
+++ b/ember-resources/src/function-based/types.ts
@@ -10,7 +10,7 @@ export interface InternalFunctionResourceConfig<Value = unknown> {
   [INTERNAL]: true;
 }
 
-export const CURRENT = Symbol('ember-resources::CURRENT');
+export const CURRENT = Symbol('ember-resources::CURRENT') as unknown as 'CURRENT';
 
 export interface GlintRenderable {
   /**

--- a/test-app/tests/core/issue-1128-test.gts
+++ b/test-app/tests/core/issue-1128-test.gts
@@ -1,10 +1,13 @@
 import Component from '@glimmer/component';
+import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { cell, resource, resourceFactory, use } from 'ember-resources';
+import { cell, resource, use } from 'ember-resources';
 
-import type { Cell, Reactive} from 'ember-resources';
+import type { Reactive} from 'ember-resources';
+
+type Cell<T> = ReturnType<typeof cell<T>>;
 
  export type ClockNakedSignature = {
   percentage: Cell<number>;
@@ -21,14 +24,23 @@ interface Signature {
   Element: HTMLDivElement;
 }
 
-const Clock = resource(({ on }) => {
+const Clock = resource(() => {
   const counter = cell(0);
   const percentage = cell(0);
 
   return { percentage, counter };
 });
 
-export default class Refresher extends Component<Signature> {
+
+class Refresher extends Component<Signature> {
+  // use (the function) exposes a .current property, like a Cell
+  clock = use(this, Clock);
+
+  <template>{{yield this.clock.current}}</template>
+}
+
+class Refresher2 extends Component<Signature> {
+  // with use (the decorator) the .current access is absorbed in an underlying getter
   @use clock = Clock;
 
   <template>{{yield this.clock}}</template>
@@ -38,7 +50,14 @@ module('issues/1128', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it works', async function () {
-
+    await render(<template>
+      <Refresher as |r|>
+        {{log r.percentage.current}}
+      </Refresher>
+      <Refresher2 as |r|>
+        {{log r.percentage.current}}
+      </Refresher2>
+    </template>);
   });
 
 });

--- a/test-app/tests/core/issue-1128-test.gts
+++ b/test-app/tests/core/issue-1128-test.gts
@@ -32,32 +32,41 @@ const Clock = resource(() => {
 });
 
 
+// use (the function) exposes a .current property, like a Cell
 class Refresher extends Component<Signature> {
-  // use (the function) exposes a .current property, like a Cell
   clock = use(this, Clock);
 
   <template>{{yield this.clock.current}}</template>
 }
 
+// with use (the decorator) the .current access is absorbed in an underlying getter
 class Refresher2 extends Component<Signature> {
-  // with use (the decorator) the .current access is absorbed in an underlying getter
   @use clock = Clock;
 
   <template>{{yield this.clock}}</template>
 }
 
+const keys = (o: Record<string, unknown>) => Object.keys(o).join(',');
+
 module('issues/1128', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it works', async function () {
+  test('it works', async function (assert) {
     await render(<template>
       <Refresher as |r|>
-        {{log r.percentage.current}}
+        <output id="one-keys">{{keys r}}</output>
+        <output id="one">{{r.percentage.current}}</output>
       </Refresher>
       <Refresher2 as |r|>
-        {{log r.percentage.current}}
+        <output id="two-keys">{{keys r}}</output>
+        <output id="two">{{r.percentage.current}}</output>
       </Refresher2>
     </template>);
+
+    assert.dom('#one-keys').hasText('percentage,counter');
+    assert.dom('#two-keys').hasText('percentage,counter');
+    assert.dom('#one').hasText('0');
+    assert.dom('#two').hasText('0');
   });
 
 });

--- a/test-app/tests/core/issue-1128-test.gts
+++ b/test-app/tests/core/issue-1128-test.gts
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { cell, resource, resourceFactory, use } from 'ember-resources';
+
+import type { Cell, Reactive} from 'ember-resources';
+
+ export type ClockNakedSignature = {
+  percentage: Cell<number>;
+  counter: Cell<number>;
+};
+
+export type ClockSignature = Reactive<ClockNakedSignature>;
+
+interface Signature {
+  Args: {};
+  Blocks: {
+    default: [ClockNakedSignature];
+  };
+  Element: HTMLDivElement;
+}
+
+const Clock = resource(({ on }) => {
+  const counter = cell(0);
+  const percentage = cell(0);
+
+  return { percentage, counter };
+});
+
+export default class Refresher extends Component<Signature> {
+  @use clock = Clock;
+
+  <template>{{yield this.clock}}</template>
+}
+
+module('issues/1128', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it works', async function () {
+
+  });
+
+});


### PR DESCRIPTION
Fix #1128 

Issues:
- `CURRENT` symbol was exposed, and caused interface matching to fail -- it has been cast to a non-symbol via the same lies @runspired is using in ember-data :sweat_smile: 

Unresolved:
- need to better declare the differences in the `use` apis