### PR TITLE
Fix issue where, in some situations, the immediate-invoker helper manager (used when you use `resourceFactory`) was not correctly destroying the previous instance of a resource (such as when args change))

### DIFF
--- a/ember-resources/src/function-based/immediate-invocation.ts
+++ b/ember-resources/src/function-based/immediate-invocation.ts
@@ -55,8 +55,18 @@ class ResourceInvokerManager {
     });
 
     setOwner(cache, this.owner);
+    associateDestroyableChild(fn, cache);
 
-    return { fn, args, cache, _: getValue(cache) };
+    /**
+     *  This ensures that we re-create everything
+     *  when args change?
+     *  TODO: verify this because I forgot to leave a comment
+     *        (though, there is a hint above)
+     */
+    let _ = getValue(cache);
+
+
+    return { fn, args, cache, _ };
   }
 
   /**
@@ -71,8 +81,8 @@ class ResourceInvokerManager {
     return getValue(resource);
   }
 
-  getDestroyable({ cache }: State) {
-    return cache;
+  getDestroyable({ fn }: State) {
+    return fn;
   }
 }
 

--- a/ember-resources/src/function-based/immediate-invocation.ts
+++ b/ember-resources/src/function-based/immediate-invocation.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { assert } from '@ember/debug';
-import { associateDestroyableChild, destroy, isDestroyed, isDestroying } from '@ember/destroyable';
+import { associateDestroyableChild, destroy } from '@ember/destroyable';
 // @ts-ignore
 import { capabilities as helperCapabilities, invokeHelper, setHelperManager } from '@ember/helper';
 import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';

--- a/ember-resources/src/function-based/resource.ts
+++ b/ember-resources/src/function-based/resource.ts
@@ -186,6 +186,7 @@ export function resource<Value>(
     let internalConfig: InternalFunctionResourceConfig<Value> = {
       definition: context as ResourceFunction<Value>,
       type: 'function-based',
+      name: 'Resource',
       [INTERNAL]: true,
     };
 
@@ -222,10 +223,19 @@ export function resource<Value>(
   let internalConfig: InternalFunctionResourceConfig<Value> = {
     definition: setup as ResourceFunction<Value>,
     type: TYPE,
+    name: getDebugName(setup),
     [INTERNAL]: true,
   };
 
   setHelperManager(ResourceManagerFactory, internalConfig);
 
   return wrapForPlainUsage(context, internalConfig);
+}
+
+function getDebugName(obj: object) {
+  if ('name' in obj) {
+    return `Resource Function: ${obj.name}`;
+  }
+
+  return `Resource Function`;
 }

--- a/ember-resources/src/function-based/types.ts
+++ b/ember-resources/src/function-based/types.ts
@@ -7,6 +7,7 @@ export const INTERNAL = '__INTERNAL__';
 export interface InternalFunctionResourceConfig<Value = unknown> {
   definition: ResourceFunction<Value>;
   type: 'function-based';
+  name: string;
   [INTERNAL]: true;
 }
 

--- a/ember-resources/tsconfig.json
+++ b/ember-resources/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
-  "include": ["src/**/*", "unpublished-development-types/**/*"],
+  "include": ["src/**/*"],
   "glint": {
     "environment": []
   },
@@ -42,8 +42,12 @@
     "allowImportingTsExtensions": true,
 
     // require extensions
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    // "module": "Node16",
+    // "moduleResolution": "Node16",
+    // TODO: enable the above when this package gets to add type=module
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "target": "esnext",
 
     // https://www.typescriptlang.org/tsconfig#stripInternal
     "stripInternal": true,
@@ -51,6 +55,8 @@
     // Build settings
     "noEmitOnError": false,
     // Just a good thing to do
-    "isolatedModules": true
+    "isolatedModules": true,
+
+    "types": ["ember-source/types"]
   }
 }

--- a/ember-resources/unpublished-development-types/index.d.ts
+++ b/ember-resources/unpublished-development-types/index.d.ts
@@ -1,2 +1,0 @@
-import 'ember-source/types';
-// import 'ember-source/types/preview';

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -1,11 +1,16 @@
 'use strict';
 
+const path = require('path');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 const packageJson = require('./package');
 
 module.exports = function (defaults) {
+  const sideWatch = require('@embroider/broccoli-side-watch');
   let app = new EmberApp(defaults, {
+    trees: {
+      app: sideWatch('app', { watching: [path.join(__dirname, '../ember-resources')] }),
+    },
     // Add options here
     autoImport: {
       watchDependencies: Object.keys(packageJson.dependencies),

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -44,6 +44,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^3.2.1",
+    "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
     "@embroider/compat": "^3.1.5",
     "@embroider/core": "^3.1.3",
     "@embroider/test-setup": "^3.0.1",

--- a/test-app/pnpm-lock.yaml
+++ b/test-app/pnpm-lock.yaml
@@ -49,6 +49,9 @@ devDependencies:
   '@ember/test-helpers':
     specifier: ^3.2.1
     version: 3.2.1(@glint/template@1.2.2)(ember-source@5.5.0)(webpack@5.89.0)
+  '@embroider/broccoli-side-watch':
+    specifier: 0.0.2-unstable.ba9fd29
+    version: 0.0.2-unstable.ba9fd29
   '@embroider/compat':
     specifier: ^3.1.5
     version: 3.4.3(@embroider/core@3.4.3)(@glint/template@1.2.2)
@@ -1519,6 +1522,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
+    dev: true
+
+  /@embroider/broccoli-side-watch@0.0.2-unstable.ba9fd29:
+    resolution: {integrity: sha512-jxMe47Rc2fUAwtKGsPy9x7gtYJpglTlbeRG5bgzs8njYZHbOiXRyhpNMcfJnn7f6Aoc4Xv4qXvTHeyye/6SyZw==}
+    dependencies:
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@embroider/compat@3.4.3(@embroider/core@3.4.3)(@glint/template@1.2.2):
@@ -3246,9 +3259,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
 

--- a/test-app/tests/core/issue-1134-test.gts
+++ b/test-app/tests/core/issue-1134-test.gts
@@ -55,7 +55,7 @@ module('issues/1134', function(hooks) {
 
     value.current = 1;
     await settled();
-    assert.verifySteps(['cleanup: 0', 'wrapper: 1', 'setup: 1']);
+    assert.verifySteps(['wrapper: 1', 'setup: 1', 'cleanup: 0']);
 
     await clearRender();
     assert.verifySteps([`cleanup: ${value.current}`]);

--- a/test-app/tests/core/issue-1134-test.gts
+++ b/test-app/tests/core/issue-1134-test.gts
@@ -1,0 +1,32 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { cell, resource, resourceFactory } from 'ember-resources';
+
+
+module('issues/1134', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it works', async function (assert) {
+    let value = cell(0);
+
+    function Wrapper(arg: number) {
+      assert.step(`wrapper: ${arg}`);
+
+      return resource(({ on }) => {
+        assert.step(`setup: ${arg}`);
+        on.cleanup(() => assert.step(`cleanup: ${arg}`));
+
+        return 0;
+      });
+    }
+
+    resourceFactory(Wrapper);
+
+    await render(<template>{{Wrapper value.current}}</template>);
+
+    assert.verifySteps([]);
+  });
+
+});

--- a/test-app/tests/core/issue-1134-test.gts
+++ b/test-app/tests/core/issue-1134-test.gts
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { clearRender,render, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
@@ -26,7 +26,14 @@ module('issues/1134', function(hooks) {
 
     await render(<template>{{Wrapper value.current}}</template>);
 
-    assert.verifySteps([]);
+    assert.verifySteps(['wrapper: 0', 'setup: 0']);
+
+    value.current = 1;
+    await settled();
+    assert.verifySteps(['cleanup: 0', 'wrapper: 1', 'setup: 1']);
+
+    await clearRender();
+    assert.verifySteps([`cleanup: ${value.current}`]);
   });
 
 });

--- a/test-app/tests/core/issue-1134-test.gts
+++ b/test-app/tests/core/issue-1134-test.gts
@@ -8,7 +8,32 @@ import { cell, resource, resourceFactory } from 'ember-resources';
 module('issues/1134', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it works', async function (assert) {
+  test('it works as a vanilla resource', async function (assert) {
+    let value = cell(0);
+
+      const Data = resource(({ on }) => {
+      let arg = value.current;
+
+        assert.step(`setup: ${arg}`);
+        on.cleanup(() => assert.step(`cleanup: ${arg}`));
+
+        return 0;
+      });
+
+    await render(<template>{{Data}}</template>);
+
+    assert.verifySteps(['setup: 0']);
+
+    value.current = 1;
+    await settled();
+    assert.verifySteps(['setup: 1', 'cleanup: 0']);
+
+    await clearRender();
+    assert.verifySteps([`cleanup: ${value.current}`]);
+
+  });
+
+  test('it works with a Wrapper (resourceFactory)', async function (assert) {
     let value = cell(0);
 
     function Wrapper(arg: number) {


### PR DESCRIPTION
Fix #1134

The issue seems specific to vanilla rendering, where your resource isn't surrounded with an if block.