### PR TITLE
Widen peer range of @glimmer/component

### DIFF
--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -54,7 +54,7 @@
     "@glimmer/component": ">= 1.1.2 || >= 2.0.0",
     "@glimmer/tracking": ">= 1.1.2",
     "@glint/template": ">= 1.0.0",
-    "ember-source": "^3.28.0 || ^4.0.0 || >= 5.0.0 || >= 6.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || >= 5.0.0"
   },
   "peerDependenciesMeta": {
     "@glimmer/component": {

--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -51,10 +51,10 @@
     "@embroider/macros": "^1.12.3"
   },
   "peerDependencies": {
-    "@glimmer/component": ">= 1.1.2",
+    "@glimmer/component": ">= 1.1.2 || >= 2.0.0",
     "@glimmer/tracking": ">= 1.1.2",
     "@glint/template": ">= 1.0.0",
-    "ember-source": "^3.28.0 || ^4.0.0 || >= 5.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || >= 5.0.0 || >= 6.0.0"
   },
   "peerDependenciesMeta": {
     "@glimmer/component": {


### PR DESCRIPTION
Now that @glimmer/component v2.0.0 is released (https://www.npmjs.com/package/@glimmer/component?activeTab=versions), I got a warning from pnpm about the peer dependencies of ember-resources