### PR TITLE
Remove ember-source virtualDeps from peerDeps

### DIFF
--- a/ember-resources/package.json
+++ b/ember-resources/package.json
@@ -52,9 +52,7 @@
   },
   "peerDependencies": {
     "@glimmer/component": ">= 1.1.2 || >= 2.0.0",
-    "@glimmer/tracking": ">= 1.1.2",
-    "@glint/template": ">= 1.0.0",
-    "ember-source": "^3.28.0 || ^4.0.0 || >= 5.0.0"
+    "@glint/template": ">= 1.0.0"
   },
   "peerDependenciesMeta": {
     "@glimmer/component": {


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries _win_ over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.