### PR TITLE
Test against 6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
           - ember-5.4
           - ember-5.8
           - ember-5.12
+          - ember-6.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,6 @@ jobs:
           - ember-5.12
           - ember-6.4
           - ember-release
-          - ember-beta
-          - ember-canary
           - embroider-safe
           - embroider-optimized
 

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -126,6 +126,15 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-6.4',
+        npm: {
+          devDependencies: {
+            ...ember6Deps,
+            'ember-source': '~6.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Also disables testing against beta and canary -- the APIs are stable -- nothing goofy going on beyond potentially tooling-related things that are unrelated to this runtime-only library