### PR TITLE
Add missing semicolon for kept imports

### DIFF
--- a/codemod/src/v6-to-v7/imports.changeNamedImport.test.ts
+++ b/codemod/src/v6-to-v7/imports.changeNamedImport.test.ts
@@ -81,7 +81,7 @@ describe('Resource', () => {
     expect(result).toMatchInlineSnapshot(`
       "
       import { Resource } from 'ember-modify-based-class-resource';
-      import { type use } from 'ember-resources'
+      import { type use } from 'ember-resources';
           "
     `);
   });
@@ -165,7 +165,7 @@ describe('Resource', () => {
     expect(result).toMatchInlineSnapshot(`
       "
       import { Resource } from 'ember-modify-based-class-resource';
-      import { resource, use } from 'ember-resources'
+      import { resource, use } from 'ember-resources';
           "
     `);
   });

--- a/codemod/src/v6-to-v7/imports.js
+++ b/codemod/src/v6-to-v7/imports.js
@@ -102,7 +102,7 @@ export function changeNamedImport(text, name, importPath, newImportPath) {
       }
 
       if (toKeep.length > 0) {
-        newLines.push(`import { ${toKeep.join(', ')} } from '${importPath}'`);
+        newLines.push(`import { ${toKeep.join(', ')} } from '${importPath}';`);
       }
 
       continue;


### PR DESCRIPTION
I had some [lint errors](https://github.com/cardstack/boxel/pull/2777/commits/c50c8b4b4b4915ccd249804ee1d42f48bb8427db) after running the codemod, easily fixed, but I can confirm that running the codemod with this change locally kept the imports along with the semicolon (resulting in no file changes).