### PR TITLE
Unwrap TrackedValue when returned from a resource

### DIFF
--- a/ember-resources/src/resource-manager.ts
+++ b/ember-resources/src/resource-manager.ts
@@ -6,6 +6,7 @@ import { associateDestroyableChild, destroy, registerDestructor } from '@ember/d
 import { invokeHelper } from '@ember/helper';
 // @ts-ignore
 import { capabilities as helperCapabilities } from '@ember/helper';
+import { appEmberSatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import { ReadonlyCell } from './cell.ts';
 import { compatOwner } from './ember-compat.ts';
@@ -20,6 +21,17 @@ import type {
 import type Owner from '@ember/owner';
 
 const setOwner = compatOwner.setOwner;
+
+/**
+ * `tracked(initialValue)` from `@glimmer/tracking` creates a standalone
+ * reactive value -- an instance of `TrackedValue` from `@glimmer/validator`.
+ * These unwrap when returned from a resource, the same way `Cell`s do.
+ */
+let TrackedValue: undefined | (new (...args: never[]) => { value: unknown });
+
+if (macroCondition(appEmberSatisfies('>=7.3.0-alpha.2'))) {
+  TrackedValue = (importSync('@glimmer/validator') as any).TrackedValue;
+}
 
 /**
  * Note, a function-resource receives on object, hooks.
@@ -124,6 +136,10 @@ class FunctionResourceManager {
 
     if (isReactive(maybeValue)) {
       return maybeValue[CURRENT];
+    }
+
+    if (TrackedValue && maybeValue instanceof TrackedValue) {
+      return maybeValue.value;
     }
 
     return maybeValue;

--- a/test-app/ember7-vite/tests/core/function-resource/tracked-value-test.gts
+++ b/test-app/ember7-vite/tests/core/function-resource/tracked-value-test.gts
@@ -1,0 +1,58 @@
+import { tracked } from '@glimmer/tracking';
+import { render, settled } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { resource } from 'ember-resources';
+
+/**
+ * `tracked(initialValue)` creates a standalone TrackedValue on
+ * ember-source >= 7.3.0-alpha.2. Returning one from a resource
+ * unwraps it, the same way returning a Cell does.
+ */
+module('Utils | (function) resource | TrackedValue', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test(`returning a TrackedValue renders its value`, async function (assert) {
+    // the runtime unwrap isn't reflected in resource()'s types, so glint
+    // doesn't know the rendered value is the TrackedValue's inner value
+    const StuckClock = resource(() => tracked(2)) as unknown as number;
+
+    await render(<template>{{StuckClock}}</template>);
+
+    assert.dom().hasText('2');
+  });
+
+  test(`updating the TrackedValue re-renders`, async function (assert) {
+    const count = tracked(0);
+    const Count = resource(() => count) as unknown as number;
+
+    await render(<template>{{Count}}</template>);
+
+    assert.dom().hasText('0');
+
+    count.value = 1;
+    await settled();
+
+    assert.dom().hasText('1');
+  });
+
+  test(`a use()-d resource returning a TrackedValue unwraps via .current`, async function (assert) {
+    const count = tracked(3);
+    const Inner = resource(() => count);
+    const Doubled = resource(({ use }) => {
+      const inner = use(Inner);
+
+      return () => Number(inner.current) * 2;
+    });
+
+    await render(<template>{{Doubled}}</template>);
+
+    assert.dom().hasText('6');
+
+    count.value = 5;
+    await settled();
+
+    assert.dom().hasText('10');
+  });
+});


### PR DESCRIPTION
## What

`ember-source >= 7.3.0-alpha.2` allows creating standalone reactive values via `tracked(initialValue)` from `@glimmer/tracking`. This makes `resource()` unwrap those the same way it unwraps `Cell`s:

```gjs
import { tracked } from '@glimmer/tracking';
import { resource } from 'ember-resources';

const Clock = resource(({ on }) => {
  let time = tracked(new Date());
  let interval = setInterval(() => (time.value = new Date()), 1000);

  on.cleanup(() => clearInterval(interval));

  return time; // previously rendered [object Object]
});
```

Now rebased down to **two files** — the macros plumbing landed via #1229 (`appEmberSatisfies`, macros ^1.19) and the CI home via #1230/#1233/#1234 (`test-app/ember7-vite`).

## How

- `instanceof` against the `TrackedValue` class ember-source exports (as a value) from `@glimmer/validator` since 7.3.0-alpha.2.
- Gated behind `macroCondition(appEmberSatisfies('>=7.3.0-alpha.2'))` — the import and check compile away entirely on older ember-source (`includePrerelease: true`, so future canaries match).

## Tests

In `test-app/ember7-vite` (pinned to the alpha, so these **run in CI**, ungated): direct return, reactive update through `.value`, composition via `use()` (whose handle exposes the unwrapped value on `.current`). 50/50 in the vite app; webpack app unaffected at 47/47 (the branch compiles out there).

Note: the runtime unwrap isn't reflected in `resource()`'s **types** — glint sees `TrackedValue<number>`, which isn't a `ContentValue`, so the tests cast at the render site. `Cell` sidesteps this by implementing `toHTML()`; possible follow-ups are a type-level unwrap in `resource()`'s signature or upstream `ContentValue`/`toHTML` support for `TrackedValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)