### PR TITLE
Remove node 18 pins from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
 
   lint:
     name: Lint
@@ -34,8 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - name: Lint
         run: pnpm lint
 
@@ -48,8 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - uses: ./.github/actions/assert-build
 
 
@@ -70,8 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - name: 'Build'
         run: pnpm build
       - name: 'Change TS to ${{ matrix.typescript-scenario }}'
@@ -114,8 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - name: 'Build'
         run: pnpm build
       - name: 'Change TS to ${{ matrix.typescript-scenario }}'
@@ -145,8 +135,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - uses: ./.github/actions/download-built-package
       - run: pnpm --filter test-app test:ember
 
@@ -170,7 +158,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
         with:
-          node-version: 18.18.1
           args: '--no-lockfile' 
       - uses: ./.github/actions/download-built-package
       - run: pnpm i -f
@@ -203,8 +190,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - uses: ./.github/actions/download-built-package
       - name: Run Tests
         working-directory: ./test-app
@@ -221,8 +206,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: wyvox/action-setup-pnpm@v3
-        with:
-          node-version: 18.18.1
       - uses: ./.github/actions/download-built-package
       - name: measure asset sizes
         run: node ./dev/estimate-bytes/index.js


### PR DESCRIPTION
## What

Removes the `node-version: 18.18.1` pin from all 9 CI jobs.

## Why

- The pins override the volta config in the root package.json (`node: 22.14.0`), so CI was testing on a different node than local development — and node 18 has been EOL since April 2025.
- With the pins gone, `wyvox/action-setup-pnpm` resolves node from the volta pin: one place to manage the version.
- This also unblocks #1230: `test-app-vite`'s toolchain (vite 8) requires node >= 20.19, and its branch currently carries a one-off unpin of the Lint job that this PR supersedes (I'll rebase #1230 once this lands).

The `floating_tests` job keeps its `with: args: '--no-lockfile'` block, minus the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)