### PR TITLE
Cap classic try scenarios at ember-source 6.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CI: true
@@ -35,7 +35,6 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-
   build:
     name: Build Tests
     needs: [install_dependencies]
@@ -46,9 +45,8 @@ jobs:
       - uses: wyvox/action-setup-pnpm@v3
       - uses: ./.github/actions/assert-build
 
-
   typecheck_legacy:
-    name: '${{ matrix.typescript-scenario }}'
+    name: "${{ matrix.typescript-scenario }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [build]
@@ -64,29 +62,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-      - name: 'Build'
+      - name: "Build"
         run: pnpm build
-      - name: 'Change TS to ${{ matrix.typescript-scenario }}'
-        run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
+      - name: "Change TS to ${{ matrix.typescript-scenario }}"
+        run: "pnpm add --save-dev ${{ matrix.typescript-scenario}}"
         working-directory: ./test-app/embroider3-webpack
 
       # This has been really annoying
       # due to injected dependencies :(
-      - name: 'Re-sync injected dependencies'
+      - name: "Re-sync injected dependencies"
         run: pnpm i -f
-      - name: 'Print Versions'
+      - name: "Print Versions"
         run: |
           pnpm --filter "test-app*" exec tsc -v;
           pnpm --filter "test-app*" exec glint --version;
 
-      - name: 'Type checking (built in types)'
+      - name: "Type checking (built in types)"
         run: pnpm --filter "test-app-old-ts" exec glint;
 
       # - name: 'Type checking (DefinitelyTyped types)'
       #   run: pnpm --filter "test-app-definitely-typed" exec glint;
 
   typecheck:
-    name: '${{ matrix.typescript-scenario }}'
+    name: "${{ matrix.typescript-scenario }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [build]
@@ -106,25 +104,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-      - name: 'Build'
+      - name: "Build"
         run: pnpm build
-      - name: 'Change TS to ${{ matrix.typescript-scenario }}'
-        run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
+      - name: "Change TS to ${{ matrix.typescript-scenario }}"
+        run: "pnpm add --save-dev ${{ matrix.typescript-scenario}}"
         working-directory: ./test-app/embroider3-webpack
 
       # This has been really annoying
       # due to injected dependencies :(
-      - name: 'Re-sync injected dependencies'
+      - name: "Re-sync injected dependencies"
         run: pnpm i -f
-      - name: 'Print Versions'
+      - name: "Print Versions"
         run: |
           pnpm --filter "test-app*" exec tsc -v;
           pnpm --filter "test-app*" exec glint --version;
 
-      - name: 'Type checking (built in types)'
+      - name: "Type checking (built in types)"
         run: pnpm --filter "test-app" exec glint;
 
-      - name: 'Type checking (DefinitelyTyped types)'
+      - name: "Type checking (DefinitelyTyped types)"
         run: pnpm --filter "test-app-definitely-typed" exec glint;
 
   default_tests:
@@ -146,7 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
-      - run: pnpm vitest 
+      - run: pnpm vitest
         working-directory: ./codemod
 
   floating_tests:
@@ -158,11 +156,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
         with:
-          args: '--no-lockfile' 
+          args: "--no-lockfile"
       - uses: ./.github/actions/download-built-package
       - run: pnpm i -f
       - run: pnpm --filter test-app test:ember
-
 
   try_scenarios:
     name: ${{ matrix.try-scenario }}
@@ -183,9 +180,7 @@ jobs:
           - ember-5.8
           - ember-5.12
           - ember-6.4
-          - ember-release
-          - embroider-safe
-          - embroider-optimized
+          - ember-6.12
 
     steps:
       - uses: actions/checkout@v4
@@ -193,9 +188,7 @@ jobs:
       - uses: ./.github/actions/download-built-package
       - name: Run Tests
         working-directory: ./test-app/embroider3-webpack
-        run: >-
-          node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
-          --skip-cleanup
+        run: node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
 
   MeasureAssetSizes:
     name: Measure Asset Sizes
@@ -214,4 +207,3 @@ jobs:
         with:
           header: asset-sizes
           path: ./dev/estimate-bytes/comment.txt
-

--- a/test-app/embroider3-webpack/app/app.ts
+++ b/test-app/embroider3-webpack/app/app.ts
@@ -9,7 +9,26 @@ import config from 'test-app/config/environment';
 
 setupDeprecationWorkflow({
   throwOnUnhandled: true,
-  workflow: [],
+  workflow: [
+    // Caused by older '@glimmer/component'
+    // (irrelevant for this test suite)
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroying-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroyed-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--register-destructor-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import-destroy-from-ember',
+    },
+  ],
 });
 
 export default class App extends Application {

--- a/test-app/embroider3-webpack/config/ember-try.js
+++ b/test-app/embroider3-webpack/config/ember-try.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
@@ -48,6 +47,18 @@ module.exports = async function () {
     'ember-load-initializers': '^3.0.1',
     'ember-resolver': '^13.1.0',
     typescript: '^5.7.0',
+  };
+
+  // we make changes here due to deprecations that were added
+  // in preparation for v7
+  const ember6_12Deps = {
+    ...ember6Deps,
+    '@glimmer/component': '^2.1.1',
+    '@ember/test-waiters': '^4.1.2',
+    '@ember/test-helpers': '^5.4.3',
+    'ember-cli': '^6.12.0',
+    'ember-resolver': '^13.2.0',
+    'ember-qunit': '^9.1.0',
   };
 
   return {
@@ -135,45 +146,33 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-release',
+        name: 'ember-6.12',
         npm: {
           devDependencies: {
-            ...ember6Deps,
-            'ember-source': await getChannelURL('release'),
+            ...ember6_12Deps,
+            'ember-source': '~6.12.0',
           },
         },
       },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            ...ember6Deps,
-            'ember-source': await getChannelURL('beta'),
-          },
-        },
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            ...ember6Deps,
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
+      /**
+       * there are enough buid differents with ember 7 recommended setup,
+       * where I just opeted to have a separate test-app.
+       * So these scenarios do not test "ember-release" as the original
+       * blueprint had us doing.
+       */
       embroiderSafe({
         npm: {
           devDependencies: {
-            ...ember6Deps,
-            'ember-source': await getChannelURL('release'),
+            ...ember6_12Deps,
+            'ember-source': '~6.12.0',
           },
         },
       }),
       embroiderOptimized({
         npm: {
           devDependencies: {
-            ...ember6Deps,
-            'ember-source': await getChannelURL('release'),
+            ...ember6_12Deps,
+            'ember-source': '~6.12.0',
           },
         },
       }),

--- a/test-app/embroider3-webpack/config/ember-try.js
+++ b/test-app/embroider3-webpack/config/ember-try.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
-
 module.exports = async function () {
   const ember3Deps = {
     'ember-maybe-import-regenerator': '^1.0.0',
@@ -152,30 +150,12 @@ module.exports = async function () {
             ...ember6_12Deps,
             'ember-source': '~6.12.0',
           },
+          overrides: {
+            ...ember6_12Deps,
+            'ember-source': '~6.12.0',
+          },
         },
       },
-      /**
-       * there are enough buid differents with ember 7 recommended setup,
-       * where I just opeted to have a separate test-app.
-       * So these scenarios do not test "ember-release" as the original
-       * blueprint had us doing.
-       */
-      embroiderSafe({
-        npm: {
-          devDependencies: {
-            ...ember6_12Deps,
-            'ember-source': '~6.12.0',
-          },
-        },
-      }),
-      embroiderOptimized({
-        npm: {
-          devDependencies: {
-            ...ember6_12Deps,
-            'ember-source': '~6.12.0',
-          },
-        },
-      }),
     ],
   };
 };

--- a/test-app/embroider3-webpack/package.json
+++ b/test-app/embroider3-webpack/package.json
@@ -68,7 +68,7 @@
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-deprecation-workflow": "^3.1.0",
+    "ember-cli-deprecation-workflow": "^4.0.1",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-load-initializers": "^2.1.2",

--- a/test-app/embroider3-webpack/pnpm-lock.yaml
+++ b/test-app/embroider3-webpack/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 2.1.2(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)(rsvp@4.8.5)(webpack@5.89.0))
       ember-resources:
         specifier: workspace:*
-        version: file:../../ember-resources(@babel/core@7.23.7)(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)
+        version: file:../../ember-resources(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)
       tracked-built-ins:
         specifier: ^3.1.0
         version: 3.3.0
@@ -130,8 +130,8 @@ importers:
         specifier: ^3.2.0
         version: 3.3.2(ember-cli@6.1.0(handlebars@4.7.8)(underscore@1.13.7))
       ember-cli-deprecation-workflow:
-        specifier: ^3.1.0
-        version: 3.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)(rsvp@4.8.5)(webpack@5.89.0))
+        specifier: ^4.0.1
+        version: 4.0.1(@babel/core@7.23.7)
       ember-cli-htmlbars:
         specifier: '>= 6.3.0'
         version: 6.3.0
@@ -1363,6 +1363,10 @@ packages:
   '@ember/test-waiters@3.1.0':
     resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
     engines: {node: 10.* || 12.* || >= 14.*}
+
+  '@embroider/addon-shim@1.10.3':
+    resolution: {integrity: sha512-GYbaiC1v9inbiwVg5s+Sd14Jc66NYxg23mEOocgWAZFCtOfhMnRLaLAA6SytW76myVVYImGHX5PFK4PVuH2yng==}
+    engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/addon-shim@1.8.7':
     resolution: {integrity: sha512-JGOQNRj3UR0NdWEg8MsM2eqPLncEwSB1IX+rwntIj22TEKj8biqx7GDgSbeH+ZedijmCh354Hf2c5rthrdzUAw==}
@@ -2996,6 +3000,9 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
+  common-ancestor-path@1.0.1:
+    resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
   common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
 
@@ -3393,6 +3400,11 @@ packages:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
 
+  decorator-transforms@2.4.0:
+    resolution: {integrity: sha512-IB+0RqnJpuS7ndH4dVY5dfWTZsrCzN3avWFdjSiET0uT2U24jKywjpVEK97TflnZkZgiSRfmeqc1WfS+1CI23w==}
+    peerDependencies:
+      '@babel/core': ^7.23.0 || ^8.0.0
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -3551,11 +3563,8 @@ packages:
     peerDependencies:
       ember-cli: ^3.2.0 || >=4.0.0
 
-  ember-cli-deprecation-workflow@3.1.0:
-    resolution: {integrity: sha512-tbN5YbEcyFEnOXN5J/TtTNAe2Qcr6bQQZgzHSLoPykiKsQ3Quq+P6BHKGzDEBK9G6YVIHFMWMmprENj+IXQTLQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      ember-source: '>= 4.0.0'
+  ember-cli-deprecation-workflow@4.0.1:
+    resolution: {integrity: sha512-XJzUZVXyb6/nFKU7GzGRlHlcAl4KtkioBTjfuIHp1aysbRZ6XxYLSPtP090EbOxQBtYwAPsH2kPAtPS86tL2RA==}
 
   ember-cli-get-component-path-option@1.0.0:
     resolution: {integrity: sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==}
@@ -9899,6 +9908,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embroider/addon-shim@1.10.3':
+    dependencies:
+      '@embroider/shared-internals': 3.1.1
+      broccoli-funnel: 3.0.8
+      common-ancestor-path: 1.0.1
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@embroider/addon-shim@1.8.7':
     dependencies:
       '@embroider/shared-internals': 2.5.1
@@ -12342,6 +12360,8 @@ snapshots:
 
   commander@8.3.0: {}
 
+  common-ancestor-path@1.0.1: {}
+
   common-path-prefix@3.0.0: {}
 
   commondir@1.0.1: {}
@@ -12580,6 +12600,11 @@ snapshots:
   decompress-response@3.3.0:
     dependencies:
       mimic-response: 1.0.1
+
+  decorator-transforms@2.4.0(@babel/core@7.23.7):
+    dependencies:
+      '@babel/core': 7.23.7(supports-color@8.1.1)
+      babel-import-util: 3.0.1
 
   deep-extend@0.6.0: {}
 
@@ -12946,12 +12971,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deprecation-workflow@3.1.0(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)(rsvp@4.8.5)(webpack@5.89.0)):
+  ember-cli-deprecation-workflow@4.0.1(@babel/core@7.23.7):
     dependencies:
-      '@babel/core': 7.23.7(supports-color@8.1.1)
-      ember-cli-babel: 8.2.0(@babel/core@7.23.7)
-      ember-source: 5.12.0(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2)(rsvp@4.8.5)(webpack@5.89.0)
+      '@embroider/addon-shim': 1.10.3
+      decorator-transforms: 2.4.0(@babel/core@7.23.7)
     transitivePeerDependencies:
+      - '@babel/core'
       - supports-color
 
   ember-cli-get-component-path-option@1.0.0: {}
@@ -13319,15 +13344,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-resources@file:../../ember-resources(@babel/core@7.23.7)(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2):
+  ember-resources@file:../../ember-resources(@glimmer/component@1.1.2(@babel/core@7.23.7))(@glint/template@1.2.2):
     dependencies:
       '@embroider/addon-shim': 1.8.7
-      '@embroider/macros': 1.20.5(@babel/core@7.23.7)(@glint/template@1.2.2)
     optionalDependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.23.7)
       '@glint/template': 1.2.2
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   ember-rfc176-data@0.3.18: {}

--- a/test-app/embroider3-webpack/tests/test-helper.ts
+++ b/test-app/embroider3-webpack/tests/test-helper.ts
@@ -3,6 +3,7 @@ import { getPendingWaiterState, getWaiters } from '@ember/test-waiters';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
+import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';
 
 import Application from 'test-app/app';
 import config from 'test-app/config/environment';
@@ -21,5 +22,12 @@ QUnit.testDone(function () {
 
 // Prevent global Errors from breaking tests
 window.onerror = console.error;
+
+if (macroCondition(dependencySatisfies('ember-qunit', '^9.0.0'))) {
+  // @ts-expect-error - importSync has no types
+  const { loadTests } = importSync('ember-qunit/test-loader');
+
+  loadTests();
+}
 
 start();


### PR DESCRIPTION
ember 7+ will have a new test-app, because I don't want a matrix of different build configurations in the same app